### PR TITLE
add ServiceBusJmsConnectionFactory version as part of user agent data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@
 #Test files
 src/test/
 
-#Resource files
-resources/
-
 #External libs
 extlib/
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
 				</executions>
 			</plugin>
 		</plugins>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources> 
 	</build>
 
 	<!-- JMS -->

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -3,8 +3,10 @@
 
 package com.microsoft.azure.servicebus.jms;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -68,7 +70,17 @@ public class ServiceBusJmsConnectionFactory implements ConnectionFactory, QueueC
             Map<String, Object> properties = new HashMap<>();
             properties.put(ServiceBusJmsConnectionFactorySettings.IsClientProvider, true);
             
+            String servicebusJmsVersion = "";
+            Properties applicationProperties = new Properties();
+            try {
+                applicationProperties.load(this.getClass().getClassLoader().getResourceAsStream("application.properties"));
+                servicebusJmsVersion = applicationProperties.getProperty("azure.servicebus.jms.version");
+            } catch (IOException e) {
+                servicebusJmsVersion = "unknown";
+            }
+            
             StringBuilder userAgent = new StringBuilder("ServiceBusJms");
+            userAgent.append("-").append(servicebusJmsVersion);
             if (customUserAgent != null && customUserAgent.length() > 0) {
                 userAgent.append("/").append(customUserAgent);
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+azure.servicebus.jms.version=${project.version}


### PR DESCRIPTION
Add `application.properties` file to allow getting the package version at runtime. The `user-agent` field sent to Azure ServiceBus will now have format of "ServiceBusJms-PackageVersionNumber" (e.g. "ServiceBusJms-0.0.4").