### PR TITLE
change default prefetch to zero and fix bug in uri query setting

### DIFF
--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -71,12 +71,13 @@ public class ServiceBusJmsConnectionFactory implements ConnectionFactory, QueueC
             settings = new ServiceBusJmsConnectionFactorySettings();
         }
         
-        String serviceBusQuery = settings.getServiceBusQuery();
-        String destinationUri = "amqps://" + host + serviceBusQuery;
+        String destinationUri = "amqps://" + host;
         if (settings.shouldReconnect()) {
             destinationUri = getReconnectUri(destinationUri, settings);
         }
         
+        String serviceBusQuery = settings.getServiceBusQuery();
+        destinationUri += serviceBusQuery;
         this.factory = new JmsConnectionFactory(sasKeyName, sasKey, destinationUri);
         this.factory.setExtension(JmsConnectionExtensions.AMQP_OPEN_PROPERTIES.toString(), (connection, uri) -> {
             Map<String, Object> properties = new HashMap<>();

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
@@ -259,6 +259,9 @@ public class ServiceBusJmsConnectionFactorySettings {
         if (traceFrames) {
             appendQuery(builder, "amqp.traceFrames", "true");
         }
+        
+        // Set prefetch to 0 by default, or else QPID will use 1000 as default value
+        appendQuery(builder, "jms.prefetchPolicy.all", "0");
 
         if (configurationOptions != null) {
             for (String option : configurationOptions.keySet()) {


### PR DESCRIPTION
- Change the default prefetch to 0 to pass tests such as TCK (set to 1000 by default by QPID JMS)
- Fix bug where the QPID JMS query parameters would be placed at the wrong spot in the query if reconnect parameters are present.
Should be: _failover:(amqp://host1:5672?failover.option=value)?jms.option=value_ 
Instead of: _failover:(amqp://host1:5672?failover.option=value&jms.option=value)_