### PR TITLE
clean up configuration options

### DIFF
--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -36,6 +36,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     private static final String CLIENT_ID_PROPERTY = "clientId";
     
     private static final int MaxCustomUserAgentLength = 128;
+    private final ServiceBusJmsConnectionFactorySettings settings;
     private volatile boolean initialized;
     private JmsConnectionFactory factory;
     private ConnectionStringBuilder builder;
@@ -44,7 +45,9 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     /**
      * Intended to be used by JNDI only. Users should not be actively calling this constructor to create a ServiceBusJmsConnectionFactory instance.
      */
-    public ServiceBusJmsConnectionFactory() { }
+    public ServiceBusJmsConnectionFactory() { 
+        this.settings = null;
+    }
     
     /**
      * Create a ServiceBusJmsConnectionFactory using a given Azure ServiceBus connection string.
@@ -64,6 +67,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
      */
     public ServiceBusJmsConnectionFactory(ConnectionStringBuilder connectionStringBuilder, ServiceBusJmsConnectionFactorySettings settings) {
         this.builder = connectionStringBuilder;
+        this.settings = settings;
         this.initialize(connectionStringBuilder.getSasKeyName(),
                 connectionStringBuilder.getSasKey(),
                 connectionStringBuilder.getEndpoint().getHost(),
@@ -78,6 +82,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
      * @param settings The options used for this ConnectionFactory. Null can be used as default.
      */
     public ServiceBusJmsConnectionFactory(String sasKeyName, String sasKey, String host, ServiceBusJmsConnectionFactorySettings settings) {
+        this.settings = settings;
         this.initialize(sasKeyName, sasKey, host, settings);
     }
     
@@ -157,6 +162,13 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
      */
     public void setClientId(String clientId) {
         this.factory.setClientID(clientId);
+    }
+    
+    /**
+     * @return The ServiceBusConnectionFactorySettings used to initialize this ServiceBusJmsConnectionFactory
+     */
+    public ServiceBusJmsConnectionFactorySettings getSettings() {
+        return this.settings;
     }
     
     @Override

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
@@ -19,7 +19,7 @@ public class ServiceBusJmsConnectionFactorySettings {
     private boolean traceFrames;
     // QPID configuration options https://qpid.apache.org/releases/qpid-jms-0.53.0/docs/index.html
     // It could be AMQP, JMS or other configurations used in the connection URI.
-    private HashMap<String, String> configurationOptions;
+    private Map<String, String> configurationOptions;
     // QPID reconnect options
     private boolean shouldReconnect = true; // Reconnect will happen by default
     private String[] reconnectHosts;
@@ -46,7 +46,7 @@ public class ServiceBusJmsConnectionFactorySettings {
      * Please see <a href="https://qpid.apache.org/releases/qpid-jms-0.41.0/docs/index.html#jms-configuration-options">
      * https://qpid.apache.org/releases/qpid-jms-0.41.0/docs/index.html#jms-configuration-options</a> for the complete list of options.
      */
-    public ServiceBusJmsConnectionFactorySettings(HashMap<String, String> configurationOptions) {
+    public ServiceBusJmsConnectionFactorySettings(Map<String, String> configurationOptions) {
         this.configurationOptions = configurationOptions;
     }
     
@@ -72,6 +72,10 @@ public class ServiceBusJmsConnectionFactorySettings {
     
     public void setTraceFrames(boolean traceFrames) {
         this.traceFrames = traceFrames;
+    }
+    
+    public Map<String, String> getConfigurationOptions() {
+        return this.configurationOptions;
     }
     
     /**
@@ -268,18 +272,20 @@ public class ServiceBusJmsConnectionFactorySettings {
             appendQuery(builder, "amqp.traceFrames", "true");
         }
         
-        if (configurationOptions != null && !configurationOptions.isEmpty()) {
-            for (String option : configurationOptions.keySet()) {
-                appendQuery(builder, option, configurationOptions.get(option));
-            }
+        if (this.configurationOptions == null) {
+            this.configurationOptions = new HashMap<String, String>();
         }
         
         // Append the default options if the ones provided by the user does not contain it.
         // Since these are query parameters, they are case sensitive.
         for (String defaultOption : DefaultConfigurationOptions.keySet()) {
             if (!configurationOptions.containsKey(defaultOption)) {
-                appendQuery(builder, defaultOption, DefaultConfigurationOptions.get(defaultOption));
+                configurationOptions.put(defaultOption, DefaultConfigurationOptions.get(defaultOption));
             }
+        }
+        
+        for (String option : configurationOptions.keySet()) {
+            appendQuery(builder, option, configurationOptions.get(option));
         }
         
         return builder.toString();

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/ConfigurationOptionsTest.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/ConfigurationOptionsTest.java
@@ -1,0 +1,56 @@
+package com.microsoft.azure.servicebus.jms.jndi;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.Connection;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings;
+import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
+
+public class ConfigurationOptionsTest {
+    ConnectionStringBuilder connectionStringBuilder;
+    
+    @Before
+    public void testInitialize() {
+        connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
+    }
+    
+    // Test that the configurationOptions match the expected default values when and only when the configurationOptions are left unset
+    @Test
+    public void defaultConfigurationsTest() throws Exception {
+        ServiceBusJmsConnectionFactory sbConnectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, new ServiceBusJmsConnectionFactorySettings());
+        Map<String, String> options = sbConnectionFactory.getSettings().getConfigurationOptions();
+        assertEquals("0", options.get("jms.prefetchPolicy.all"));
+        try(Connection connection = sbConnectionFactory.createConnection()) {
+            connection.start();
+            connection.createSession();
+        }
+        
+        Map<String, String> expectedOptions = new HashMap<String, String>();
+        expectedOptions.put("jms.prefetchPolicy.all", "100");
+        ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(options);
+        sbConnectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, settings);
+        Map<String, String> actualOptions = sbConnectionFactory.getSettings().getConfigurationOptions();
+        assertEquals("100", actualOptions.get("jms.prefetchPolicy.all"));
+        try(Connection connection = sbConnectionFactory.createConnection()) {
+            connection.start();
+            connection.createSession();
+        }
+    }
+    
+    // Test that ConnectionFactory runs when the ServiceBusJmsConnectionFactorySettings are null
+    @Test
+    public void nullConfigurationsTest() throws Exception {
+        ServiceBusJmsConnectionFactory sbConnectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, null);
+        try(Connection connection = sbConnectionFactory.createConnection()) {
+            connection.start();
+            connection.createSession();
+        }
+    }
+}


### PR DESCRIPTION
- Fix bug where configuration may result in null pointer
- Broaden the public contract of the configurations from HashMap to generic Map interface.
- Add tests for default and null configuration options