### PR TITLE
Adding aad authentication support for jms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-servicebus-jms</artifactId>
-	<version>0.0.9</version>
+	<version>1.0.0</version>
 	<name>azure-servicebus-jms</name>
 	<description>ServiceBus ConnectionFactory for JMS users</description>
 
@@ -83,6 +83,17 @@
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+		    <groupId>com.azure</groupId>
+		    <artifactId>azure-identity</artifactId>
+		    <version>1.6.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -6,10 +6,13 @@ package com.microsoft.azure.servicebus.jms;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import javax.jms.Connection;
@@ -24,6 +27,9 @@ import javax.jms.TopicConnectionFactory;
 import org.apache.qpid.jms.JmsConnectionExtensions;
 import org.apache.qpid.jms.JmsConnectionFactory;
 
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
 import com.microsoft.azure.servicebus.jms.jndi.JNDIStorable;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 
@@ -34,13 +40,24 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     // JNDI property names
     private static final String CONNECTION_STRING_PROPERTY = "connectionString";
     private static final String CLIENT_ID_PROPERTY = "clientId";
-    
+    private static final String AUDIENCE = "https://servicebus.azure.net/.default";
+    private static final String AUTHORITY = "https://login.microsoftonline.com/%s/";
     private static final int MaxCustomUserAgentLength = 128;
+    
     private final ServiceBusJmsConnectionFactorySettings settings;
     private volatile boolean initialized;
     private JmsConnectionFactory factory;
     private ConnectionStringBuilder builder;
     private String customUserAgent;
+    
+    private String tenantId; 
+    private String aadClientId; 
+    private String clientSecret;
+    private String keyName;
+    private String keyValue;
+    private boolean isToken;
+    private boolean userToken;
+    private TokenRequestContext context;
     
     /**
      * Intended to be used by JNDI only. Users should not be actively calling this constructor to create a ServiceBusJmsConnectionFactory instance.
@@ -68,8 +85,9 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     public ServiceBusJmsConnectionFactory(ConnectionStringBuilder connectionStringBuilder, ServiceBusJmsConnectionFactorySettings settings) {
         this.builder = connectionStringBuilder;
         this.settings = settings;
-        this.initialize(connectionStringBuilder.getSasKeyName(),
-                connectionStringBuilder.getSasKey(),
+        this.setKeyValue(connectionStringBuilder.getSasKey());
+        this.keyName = connectionStringBuilder.getSasKeyName();
+        this.initialize(
                 connectionStringBuilder.getEndpoint().getHost(),
                 settings);
     }
@@ -83,21 +101,49 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
      */
     public ServiceBusJmsConnectionFactory(String sasKeyName, String sasKey, String host, ServiceBusJmsConnectionFactorySettings settings) {
         this.settings = settings;
-        this.initialize(sasKeyName, sasKey, host, settings);
+        this.setKeyValue(sasKey);
+        this.keyName = sasKeyName;
+        this.initialize(host, settings);
     }
     
-    private void initialize(String sasKeyName, String sasKey, String host, ServiceBusJmsConnectionFactorySettings settings) {
-        if (sasKeyName == null || sasKeyName == null || host == null) {
-            throw new IllegalArgumentException("SAS Key, SAS KeyName and the host cannot be null for a ServiceBus connection factory.");
-        }
-        
+    /**
+     * Create a ServiceBusJmsConnectionFactory using shared access key and host name.
+     * @param tenantId Tenent id 
+     * @param clientId Client id.
+     * @param clientSecret Client secret
+     * @param host The host name of the ServiceBus namespace. Example: your-namespace-name.servicebus.windows.net
+     * @param settings The options used for this ConnectionFactory. Null can be used as default.
+     */
+    public ServiceBusJmsConnectionFactory(String tenantId, String clientId, String clientSecret, String host, ServiceBusJmsConnectionFactorySettings settings) {
+        this.settings = settings;
+        this.setIsToken(true);
+        this.setTenantId(tenantId);
+        this.setAadClientId(clientId);
+        this.setClientSecret(clientSecret);
+        this.initialize(host, settings);
+    }
+    
+    public ServiceBusJmsConnectionFactory(String token, String host, ServiceBusJmsConnectionFactorySettings settings, boolean isToken) {
+        this.settings = settings;
+        this.setIsToken(isToken);
+        this.setKeyValue (token);
+        this.userToken = true;
+        this.initialize(host, settings);
+    }
+    
+    private void initialize(String host, ServiceBusJmsConnectionFactorySettings settings) {
+    	if (!this.isToken) {
+	        if (keyName == null || keyName == null || host == null) {
+	            throw new IllegalArgumentException("SAS Key, SAS KeyName and the host cannot be null for a ServiceBus connection factory.");
+	        }
+    	}
         if (settings == null) {
             settings = new ServiceBusJmsConnectionFactorySettings();
         }
         
         if (this.builder == null) {
             try {
-                this.builder = new ConnectionStringBuilder(new URI(host), null, sasKeyName, sasKey);
+                this.builder = new ConnectionStringBuilder(new URI(host), null, keyName, keyValue);
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
@@ -110,7 +156,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         
         String serviceBusQuery = settings.getServiceBusQuery();
         destinationUri += serviceBusQuery;
-        this.factory = new JmsConnectionFactory(sasKeyName, sasKey, destinationUri);
+        this.factory = new JmsConnectionFactory(keyName, keyValue, destinationUri);
         this.factory.setExtension(JmsConnectionExtensions.AMQP_OPEN_PROPERTIES.toString(), (connection, uri) -> {
             Map<String, Object> properties = new HashMap<>();
             properties.put(ServiceBusJmsConnectionFactorySettings.IsClientProvider, true);
@@ -134,6 +180,17 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
 
             return properties;
         });
+        
+        if (isToken) {
+        	this.factory = new JmsConnectionFactory(destinationUri);
+        	this.factory.setExtension(JmsConnectionExtensions.USERNAME_OVERRIDE.toString(), (connection, uri) -> {        		
+        		return "$jwt";
+        	});
+            this.factory.setExtension(JmsConnectionExtensions.PASSWORD_OVERRIDE.toString(), GetToken);
+        }
+        else {
+        	this.factory = new JmsConnectionFactory(keyName, this.getKeyValue(), destinationUri);
+        }
 
         Supplier<ProxyHandler> proxyHandlerSupplier = settings.getProxyHandlerSupplier();
         if (proxyHandlerSupplier != null) {
@@ -280,7 +337,9 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         
         this.checkRequiredProperty(CONNECTION_STRING_PROPERTY, connectionString);
         this.builder = new ConnectionStringBuilder(connectionString);
-        this.initialize(this.builder.getSasKeyName(), this.builder.getSasKey(), this.builder.getEndpoint().getHost(), null);
+        this.keyValue = this.builder.getSasKey();
+        this.keyName = this.builder.getSasKeyName(); 
+        this.initialize(this.builder.getEndpoint().getHost(), null);
     
         // Need to wait until the inner factory is initialized in order to set the clientId
         if (!StringUtil.isNullOrEmpty(clientId)) {
@@ -333,4 +392,99 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
             throw new RuntimeException("This ServiceBusJmsConnectionFactory object is not initialized with the proper parameters.");
         }
     }
+    
+    private BiFunction<Connection, URI, Object> GetToken = new BiFunction<Connection, URI, Object>()
+	{
+	    private volatile String token;
+	    	   	 
+	    @Override
+	    public Object apply(final Connection connection, final URI uri) 
+	    {
+	    	if(userToken) {
+	    		return getKeyValue();
+	    	}
+	    	else {
+		    	String tenantId = getTenantId();
+			    String clientSecret = getClientSecret(); 
+			    String aadClientId =  getAadClientId();;
+			    String authority =  String.format(AUTHORITY, tenantId);
+	
+		    	List<String> scopes = new ArrayList<String>();
+			    scopes.add(AUDIENCE);
+	
+			    ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+			    		.tenantId(tenantId)
+			    		.clientId(aadClientId)
+			    		.clientSecret(clientSecret)
+			    		.authorityHost(authority)	    		
+			    		.build();
+			    
+			    if (context == null ) {
+			    	TokenRequestContext cxt = new TokenRequestContext();
+			    	cxt.setTenantId(tenantId);
+			    	cxt.setScopes(scopes);
+			    	//cxt.setClaims(claims);
+		
+				    token = credential
+			        		.getToken(cxt).block()
+			                .getToken();
+			    }
+			    else {		    	
+				    token = credential
+			        		.getToken(context).block()
+			                .getToken();
+			    }
+			    
+			    return token;
+	    	}
+	    }
+	};
+
+	public TokenRequestContext context() {
+		return this.context;
+	}
+
+	public void setContext(TokenRequestContext context) {
+		this.context = context;
+	}
+	
+	public boolean isToken() {
+		return this.isToken;
+	}
+
+	public void setIsToken(boolean isToken) {
+		this.isToken = isToken;
+	}
+	
+	public String getKeyValue() {
+		return this.keyValue;
+	}
+
+	public void setKeyValue(String token) {
+		this.keyValue = token;
+	}
+
+	public String getTenantId() {
+		return this.tenantId;
+	}
+
+	public void setTenantId(String tenantId) {
+		this.tenantId = tenantId;
+	}
+
+	public String getClientSecret() {
+		return this.clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
+
+	public String getAadClientId() {
+		return this.aadClientId;
+	}
+
+	public void setAadClientId(String aadClientId) {
+		this.aadClientId = aadClientId;
+	}
 }

--- a/src/test/java/com/microsoft/azure/servicebus/jms/aad/SendReceiveTest.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/aad/SendReceiveTest.java
@@ -1,0 +1,219 @@
+package com.microsoft.azure.servicebus.jms.aad;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+
+public class SendReceiveTest 
+{
+	private static final String AUDIENCE = "https://servicebus.azure.net/.default";
+    private static final String AUTHORITY = "https://login.microsoftonline.com/%s/";
+    
+    private MessageConsumer consumer = null;
+    private MessageProducer producer = null;
+    private TextMessage receivedMessage = null;
+    private TextMessage message = null;
+    
+    ServiceBusJmsConnectionFactory sbConnectionFactoryExtensionToken;
+    ServiceBusJmsConnectionFactory sbConnectionFactoryUserToken;
+    
+    @Before
+    public void Initialize() 
+    {
+		String token = GetToken();
+    	sbConnectionFactoryExtensionToken = new ServiceBusJmsConnectionFactory(Utility.TENANT_ID, Utility.CLIENT_ID, Utility.CLIENT_SECRET, Utility.HOST, Utility.CONNECTION_SETTINGS);
+    	sbConnectionFactoryUserToken = new ServiceBusJmsConnectionFactory(token, Utility.HOST, Utility.CONNECTION_SETTINGS, true);
+    }
+	
+	@Test
+    public void SendReceiveQueueWithTokenGenerated() throws Exception  
+    {		    
+		Connection sendConnection = sbConnectionFactoryExtensionToken.createConnection();
+		Connection receiveConnection = sbConnectionFactoryExtensionToken.createConnection();
+       
+		System.out.println();
+        System.out.println("Testing Queue with Token Generated");
+        Send(sendConnection, "generatedtoken", true);
+        ConsumerQueue(receiveConnection, "generatedtoken");
+	}
+	
+	@Test
+    public void SendReceiveQueueUserToken() throws Exception 
+    {
+		Connection sendConnection = sbConnectionFactoryUserToken.createConnection();
+		Connection receiveConnection = sbConnectionFactoryUserToken.createConnection();
+	    
+        System.out.println();
+        System.out.println("Testing Queue with User Token");
+        Send(sendConnection, "usertoken", true);
+        ConsumerQueue(receiveConnection, "usertoken");
+    }
+	
+	@Test
+    public void SendReceiveTopicWithTokenGenerated() throws Exception 
+    {
+		Connection sendConnection = sbConnectionFactoryExtensionToken.createConnection();
+		Connection receiveConnection = sbConnectionFactoryExtensionToken.createConnection();
+	
+	    System.out.println();
+        System.out.println("Testing Topic with Token Generated");
+        Send(sendConnection, "topicgeneratedtoken", false);
+        ConsumerTopic(receiveConnection, "TokenGenerated", "topicgeneratedtoken", "subGenToken");
+    }
+	
+	@Test
+    public void SendReceiveTopicWithUserToken() throws Exception 
+    {		
+		Connection sendConnection = sbConnectionFactoryUserToken.createConnection();
+		Connection receiveConnection = sbConnectionFactoryUserToken.createConnection();	
+		
+		System.out.println();
+        System.out.println("Testing Topic with Token Generated");		
+		Send(sendConnection, "topicusertoken", false);
+		ConsumerTopic(receiveConnection, "UserToken", "topicusertoken", "subUserToken");
+    }
+	
+	public void Send(Connection connection, String entityName, boolean isQueue) throws Exception
+	{
+		Queue queue = null;
+	    Topic topic = null;
+	    
+		connection.start();
+		Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+		Destination destination = null;
+		
+		try {
+			if (isQueue)
+			{
+				queue = session.createQueue(entityName);
+				destination = queue;
+			}
+			else {
+				topic = session.createTopic(entityName);
+				destination = topic;			
+			}
+			
+			producer = session.createProducer(destination);
+            String requestText = "Hello jms!";
+            message = session.createTextMessage(requestText);
+            
+            producer.send(message);
+            System.out.println("Sending One message...");
+            System.out.println("Message sent");
+            System.out.println();
+            
+            System.out.println("Sending 5 message.....");
+            for(int i = 0; i<5; i++)
+            {
+            	producer.send(message);
+            	System.out.println("Message " + i + " sent....");              
+            }
+ 
+        } finally {
+            if (session != null) session.close();
+            if (connection != null) connection.close();
+        }
+	}
+	
+	public void ConsumerQueue(Connection connection, String entityName) throws Exception
+	{
+		connection.start();
+		Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+		Queue queue = null;
+	    
+		try 
+		{
+			queue = session.createQueue(entityName);
+			consumer = session.createConsumer(queue);
+            receivedMessage = (TextMessage)consumer.receive(Utility.DEFAULT_TIMEOUT);
+            System.out.println("Receiving message...");
+            System.out.println();
+            assertNotNull(receivedMessage.getText());
+            
+            for(int i = 0; i<6; i++)
+            {                            	
+            	receivedMessage = (TextMessage)consumer.receive(Utility.DEFAULT_TIMEOUT);
+            	System.out.println("Receiving " + i + " message..."); 
+            	assertNotNull(receivedMessage.getText());               
+            }
+        } 
+		finally 
+		{
+            if (session != null) session.close();
+            if (connection != null) connection.close();
+        }
+	}
+	
+	private void ConsumerTopic(Connection connection, String clientId, String topicName, String subscriptionName) throws JMSException
+	{
+		connection.setClientID(clientId);
+		connection.start();
+		Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+		Topic topic = null;
+		
+		try 
+		{
+			session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+			topic = session.createTopic(topicName);
+		
+			consumer = session.createDurableConsumer(topic, subscriptionName);
+	        receivedMessage = (TextMessage)consumer.receive(Utility.DEFAULT_TIMEOUT);
+	        System.out.println("Receiving message...");
+	        System.out.println();
+	        assertNotNull(receivedMessage.getText());
+	        
+	        System.out.println("Sending 5 message.....");
+	        for(int i = 0; i<5; i++)
+	        {                            	
+	        	receivedMessage = (TextMessage)consumer.receive(Utility.DEFAULT_TIMEOUT);
+	        	System.out.println("Receiving " + i + " message..."); 
+	        	assertNotNull(receivedMessage.getText());               
+	        }
+		} 
+		finally 
+		{
+	        if (session != null) session.close();
+	        if (connection != null) connection.close();
+	    }
+	}
+	
+	private String GetToken()
+	{
+		String authority =  String.format(AUTHORITY, Utility.TENANT_ID);
+		
+		List<String> scopes = new ArrayList<String>();
+	    scopes.add(AUDIENCE);
+
+	    ClientSecretCredential credential = new ClientSecretCredentialBuilder()
+	    		.tenantId(Utility.TENANT_ID)
+	    		.clientId(Utility.CLIENT_ID)
+	    		.clientSecret(Utility.CLIENT_SECRET)
+	    		.authorityHost(authority)	    		
+	    		.build();
+	    
+	    	TokenRequestContext cxt = new TokenRequestContext();
+	    	cxt.setTenantId(Utility.TENANT_ID);
+	    	cxt.setScopes(scopes);
+
+		    return credential
+	        		.getToken(cxt).block()
+	                .getToken();		          
+	}
+}

--- a/src/test/java/com/microsoft/azure/servicebus/jms/aad/Utility.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/aad/Utility.java
@@ -1,0 +1,23 @@
+package com.microsoft.azure.servicebus.jms.aad;
+
+import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings;
+
+public class Utility {
+	
+	public static final ServiceBusJmsConnectionFactorySettings CONNECTION_SETTINGS;
+	public static final String TENANT_ID;
+	public static final String CLIENT_SECRET;
+	public static final String CLIENT_ID;
+	public static final String HOST;
+	public static final long DEFAULT_TIMEOUT;
+	
+    static {
+        
+        CONNECTION_SETTINGS = new ServiceBusJmsConnectionFactorySettings(120000, true);
+        TENANT_ID =  System.getenv("TENANT_ID");
+        CLIENT_SECRET = System.getenv("CLIENT_SECRET");
+        CLIENT_ID = System.getenv("CLIENT_ID");
+        HOST = System.getenv("HOST_NAMESPACE");
+        DEFAULT_TIMEOUT = 3000;
+    }
+}


### PR DESCRIPTION
For jms we need to modify factory on client side so that we had the option of passing a token or client side of sevicebus generate a toke by providing tenant id, client id and client secrete. 