### PR TITLE
Enable a way for customers to be able to specify autodelete on entities created through JMS

### DIFF
--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -172,6 +172,21 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
             
             properties.put("user-agent", userAgent.toString());
 
+            long queueAutoDeleteOnIdleDurationInSeconds = this.settings.getQueueAutoDeleteOnIdleDurationInSeconds();
+            if (queueAutoDeleteOnIdleDurationInSeconds > 0) {
+            	properties.put(ServiceBusJmsConnectionFactorySettings.QueueAutoDeleteOnIdleDurationInSecondsName, queueAutoDeleteOnIdleDurationInSeconds);
+            }
+            
+            long topicAutoDeleteOnIdleDurationInSeconds = this.settings.getTopicAutoDeleteOnIdleDurationInSeconds();
+            if (topicAutoDeleteOnIdleDurationInSeconds > 0) {
+            	properties.put(ServiceBusJmsConnectionFactorySettings.TopicAutoDeleteOnIdleDurationInSecondsName, topicAutoDeleteOnIdleDurationInSeconds);
+            }
+            
+            long subscriberAutoDeleteOnIdleDurationInSeconds = this.settings.getSubscriberAutoDeleteOnIdleDurationInSeconds();
+            if (subscriberAutoDeleteOnIdleDurationInSeconds > 0) {
+            	properties.put(ServiceBusJmsConnectionFactorySettings.SubscriberAutoDeleteOnIdleDurationInSecondsName, subscriberAutoDeleteOnIdleDurationInSeconds);
+            }
+
             return properties;
         });  
 

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
@@ -81,11 +81,11 @@ public class ServiceBusJmsConnectionFactorySettings {
         this.traceFrames = traceFrames;
     }
 
-	/**
-	 * @return the queueAutoDeleteOnIdleDurationInSeconds setting configured for the factory
-	 */
+    /**
+     * @return the queueAutoDeleteOnIdleDurationInSeconds setting configured for the factory
+     */
 	public long getQueueAutoDeleteOnIdleDurationInSeconds() {
-		return queueAutoDeleteOnIdleDurationInSeconds;
+		return this.queueAutoDeleteOnIdleDurationInSeconds;
 	}
 
 	/**
@@ -100,7 +100,7 @@ public class ServiceBusJmsConnectionFactorySettings {
 	 * @return the topicAutoDeleteOnIdleDurationInSeconds setting configured for the factory
 	 */
 	public long getTopicAutoDeleteOnIdleDurationInSeconds() {
-		return topicAutoDeleteOnIdleDurationInSeconds;
+		return this.topicAutoDeleteOnIdleDurationInSeconds;
 	}
 
 	/**
@@ -110,13 +110,12 @@ public class ServiceBusJmsConnectionFactorySettings {
 	public void setTopicAutoDeleteOnIdleDurationInSeconds(long topicAutoDeleteOnIdleDurationInSeconds) {
 		this.topicAutoDeleteOnIdleDurationInSeconds = topicAutoDeleteOnIdleDurationInSeconds;
 	}
-
     
-    /**
+	/**
 	 * @return the subscriberAutoDeleteOnIdleDurationInSeconds setting configured for the factory
 	 */
 	public long getSubscriberAutoDeleteOnIdleDurationInSeconds() {
-		return subscriberAutoDeleteOnIdleDurationInSeconds;
+		return this.subscriberAutoDeleteOnIdleDurationInSeconds;
 	}
 
 	/**

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
@@ -12,11 +12,18 @@ import io.netty.handler.proxy.ProxyHandler;
 public class ServiceBusJmsConnectionFactorySettings {
     private static Map<String, String> DefaultConfigurationOptions = getDefaultConfigurationOptions();
     
+    static final String Vendor = "com.microsoft";
     // a flag added to the AMQP connection to indicate it's a ServiceBus ConnectionFactory client
-    static final String IsClientProvider = "com.microsoft:is-client-provider";
+    static final String IsClientProvider = Vendor + ":is-client-provider";
+    static final String QueueAutoDeleteOnIdleDurationInSecondsName = Vendor + ":queue-auto-delete-on-idle-duration-in-seconds";
+    static final String TopicAutoDeleteOnIdleDurationInSecondsName = Vendor + ":topic-auto-delete-on-idle-duration-in-seconds";
+    static final String SubscriberAutoDeleteOnIdleDurationInSecondsName = Vendor + ":subscriber-auto-delete-on-idle-duration-in-seconds";
     private long connectionIdleTimeoutMS;
     private Supplier<ProxyHandler> proxyHandlerSupplier;
     private boolean traceFrames;
+    private long queueAutoDeleteOnIdleDurationInSeconds;
+    private long topicAutoDeleteOnIdleDurationInSeconds;
+    private long subscriberAutoDeleteOnIdleDurationInSeconds;
     // QPID configuration options https://qpid.apache.org/releases/qpid-jms-0.53.0/docs/index.html
     // It could be AMQP, JMS or other configurations used in the connection URI.
     private Map<String, String> configurationOptions;
@@ -73,8 +80,54 @@ public class ServiceBusJmsConnectionFactorySettings {
     public void setTraceFrames(boolean traceFrames) {
         this.traceFrames = traceFrames;
     }
+
+	/**
+	 * @return the queueAutoDeleteOnIdleDurationInSeconds setting configured for the factory
+	 */
+	public long getQueueAutoDeleteOnIdleDurationInSeconds() {
+		return queueAutoDeleteOnIdleDurationInSeconds;
+	}
+
+	/**
+	 * @param queueAutoDeleteOnIdleDurationInSeconds - the autoDeleteOnIdleDurationInSeconds to be set for all queues created using this factory.
+	 * If different queues need different AutoDeleteOnIdleDuration settings, use different ServiceBusJmsConnectionFactory to create those queues.
+	 */
+	public void setQueueAutoDeleteOnIdleDurationInSeconds(long queueAutoDeleteOnIdleDurationInSeconds) {
+		this.queueAutoDeleteOnIdleDurationInSeconds = queueAutoDeleteOnIdleDurationInSeconds;
+	}
+
+	/**
+	 * @return the topicAutoDeleteOnIdleDurationInSeconds setting configured for the factory
+	 */
+	public long getTopicAutoDeleteOnIdleDurationInSeconds() {
+		return topicAutoDeleteOnIdleDurationInSeconds;
+	}
+
+	/**
+	 * @param topicAutoDeleteOnIdleDurationInSeconds - the autoDeleteOnIdleDurationInSeconds to be set for all topics created using this factory.
+	 * If different topics need different AutoDeleteOnIdleDuration settings, use different ServiceBusJmsConnectionFactory to create those topics.
+	 */
+	public void setTopicAutoDeleteOnIdleDurationInSeconds(long topicAutoDeleteOnIdleDurationInSeconds) {
+		this.topicAutoDeleteOnIdleDurationInSeconds = topicAutoDeleteOnIdleDurationInSeconds;
+	}
+
     
-    public Map<String, String> getConfigurationOptions() {
+    /**
+	 * @return the subscriberAutoDeleteOnIdleDurationInSeconds setting configured for the factory
+	 */
+	public long getSubscriberAutoDeleteOnIdleDurationInSeconds() {
+		return subscriberAutoDeleteOnIdleDurationInSeconds;
+	}
+
+	/**
+	 * @param subscriberAutoDeleteOnIdleDurationInSeconds - the autoDeleteOnIdleDurationInSeconds to be set for all subscriptions created using this factory.
+	 * If different subscriptions need different AutoDeleteOnIdleDuration settings, use different ServiceBusJmsConnectionFactory to create those subscriptions.
+	 */
+	public void setSubscriberAutoDeleteOnIdleDurationInSeconds(long subscriberAutoDeleteOnIdleDurationInSeconds) {
+		this.subscriberAutoDeleteOnIdleDurationInSeconds = subscriberAutoDeleteOnIdleDurationInSeconds;
+	}
+
+	public Map<String, String> getConfigurationOptions() {
         return this.configurationOptions;
     }
     


### PR DESCRIPTION
How will this work:
When using ServiceBus JMS library, customer can additionally make use of the following APIs in the ServiceBusJmsConnectionFactorySettings to configure the AutoDeleteOnIdle behavior for entities created through this factory.

For Queues:
	setQueueAutoDeleteOnIdleDurationInSeconds(long queueAutoDeleteOnIdleDurationInSeconds);
For Topics:
	setTopicAutoDeleteOnIdleDurationInSeconds(long topicAutoDeleteOnIdleDurationInSeconds);
For Subscriptions:
	setSubscriberAutoDeleteOnIdleDurationInSeconds(long subscriberAutoDeleteOnIdleDurationInSeconds);

Once set, the service should monitor and honor the AutoDeleteOnIdle behavior by deleting the entity after specified period of inactivity.

When present on the factory any queue/topic/subscriber created through this factory will be created with AutoDeleteOnIdle enabled with that setting.

Caveats:

1. If different queues/Topics need different AutoDeleteOnIdle timeout then customer will need to use different factories for that.
2. Since JMS does not really have an update API, it will not be possible to Update the setting. The only way to update the property will be through ARM/portal for that entity.


It is also hard to add verifiable automated tests for this feature, as JMS has the behavior of dynamic creation of entities, if entities do not exist at the time of Send/Receive.

Hence sending a PR without those tests. The feature will be manually verified by setting it and then verifying from the Service that entity did get cleaned up by using a management tool like portal.