### PR TITLE
Fixing Jndi bug introduce by autodelete setting is null

### DIFF
--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -81,7 +81,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.password = connectionStringBuilder.getSasKey();
         this.userName = connectionStringBuilder.getSasKeyName();
         this.host = connectionStringBuilder.getEndpoint().getHost();
-        this.initializeWithSas();        
+        this.initializeWithSas();
     }
     
     /**

--- a/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/microsoft/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -42,7 +42,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     private AadAuthentication aadAuthentication;
    
     //Common properties
-    private final ServiceBusJmsConnectionFactorySettings settings;
+    private ServiceBusJmsConnectionFactorySettings settings;
     private volatile boolean initialized;
     private JmsConnectionFactory factory;
     private ConnectionStringBuilder builder;
@@ -53,6 +53,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     
     /**
      * Intended to be used by JNDI only. Users should not be actively calling this constructor to create a ServiceBusJmsConnectionFactory instance.
+     * So far only use by JNDIConnectionFactoryTests. 
      */
     public ServiceBusJmsConnectionFactory() { 
         this.settings = null;
@@ -80,8 +81,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.password = connectionStringBuilder.getSasKey();
         this.userName = connectionStringBuilder.getSasKeyName();
         this.host = connectionStringBuilder.getEndpoint().getHost();
-        this.initializeWithSas();
-        
+        this.initializeWithSas();        
     }
     
     /**
@@ -115,14 +115,21 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     }
     
     private void initializeWithAad() {
-    	this.initialize(this.userName, this.password, this.host, this.settings);
+        if (this.settings == null) {
+            this.settings = new ServiceBusJmsConnectionFactorySettings();
+        }
+
+    	this.initialize(this.userName, this.password, this.host);
     	this.setExtensionsForAad();
     	this.initialized = true;
     }
     
     private void initializeWithSas() {
+        if (this.settings == null) {
+            this.settings = new ServiceBusJmsConnectionFactorySettings();
+        }
 
-    	this.initialize(this.userName, this.password, this.host, this.settings);
+    	this.initialize(this.userName, this.password, this.host);
     	if (this.builder == null) {
             try {
                 this.builder = new ConnectionStringBuilder(new URI(host), null, this.userName, this.password);
@@ -134,20 +141,17 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     	this.initialized = true;
     }
     
-    private void initialize(String userName, String password, String host, ServiceBusJmsConnectionFactorySettings settings) {
+    private void initialize(String userName, String password, String host) {
     	if (userName == null || password == null || host == null) {
             throw new IllegalArgumentException("Authentication settings and host cannot be null for a Service Bus connection factory.");
         }
-        if (settings == null) {
-            settings = new ServiceBusJmsConnectionFactorySettings();
-        }
-                
+        
         String destinationUri = "amqps://" + host;
-        if (settings.shouldReconnect()) {
-            destinationUri = getReconnectUri(destinationUri, settings);
+        if (this.settings.shouldReconnect()) {
+            destinationUri = getReconnectUri(destinationUri, this.settings);
         }
         
-        String serviceBusQuery = settings.getServiceBusQuery();
+        String serviceBusQuery = this.settings.getServiceBusQuery();
         destinationUri += serviceBusQuery;
         this.factory = new JmsConnectionFactory(userName, password, destinationUri);
         
@@ -190,7 +194,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
             return properties;
         });  
 
-        Supplier<ProxyHandler> proxyHandlerSupplier = settings.getProxyHandlerSupplier();
+        Supplier<ProxyHandler> proxyHandlerSupplier = this.settings.getProxyHandlerSupplier();
         if (proxyHandlerSupplier != null) {
             factory.setExtension(JmsConnectionExtensions.PROXY_HANDLER_SUPPLIER.toString(), (connection, remote) -> {
                 return proxyHandlerSupplier;

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/ConfigurationOptionsTest.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/ConfigurationOptionsTest.java
@@ -35,7 +35,7 @@ public class ConfigurationOptionsTest {
         
         Map<String, String> expectedOptions = new HashMap<String, String>();
         expectedOptions.put("jms.prefetchPolicy.all", "100");
-        ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(options);
+        ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(expectedOptions);
         sbConnectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, settings);
         Map<String, String> actualOptions = sbConnectionFactory.getSettings().getConfigurationOptions();
         assertEquals("100", actualOptions.get("jms.prefetchPolicy.all"));


### PR DESCRIPTION
Dependencies update to ensure security compliance and to move to jakarta for spring compliance. During testing I found out Jndi bug introduced by autodelete on entities

### Bugs
- Jndi fix introduced by "Enable a way for customers to be able to specify autodelete on entities created through JMS (#36)". 

Jndi can have null settings so when auto delete feature was introduce it assume it was never null.  However, when Jndi is used it will always hang and try to connect until the app is interred, adding a null checker for setting when we set factory extension. 