### PR TITLE
Update qpid.jms.client and other dependencies for compliance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ target
 
 # Windows #
 Thumbs.db
+
+# vscode
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-servicebus-jms</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<name>azure-servicebus-jms</name>
 	<description>ServiceBus ConnectionFactory for JMS users</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,5 +79,10 @@
 		    <artifactId>azure-identity</artifactId>
 		    <version>1.11.2</version>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.jms</groupId>
+			<artifactId>jakarta.jms-api</artifactId>
+			<version>2.0.3</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.5</version>
+				<version>3.11.0</version>
 				<configuration>
 					<goalPrefix>service-bus-jms-connection-factory</goalPrefix>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -66,23 +66,18 @@
 		<dependency>
 			<groupId>org.apache.qpid</groupId>
 			<artifactId>qpid-jms-client</artifactId>
-			<version>0.53.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.geronimo.specs</groupId>
-			<artifactId>geronimo-jms_2.0_spec</artifactId>
-			<version>LATEST</version>
+			<version>1.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 		    <groupId>com.azure</groupId>
 		    <artifactId>azure-identity</artifactId>
-		    <version>1.7.3</version>
+		    <version>1.11.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,9 @@
 			<version>1.11.0</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.10.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/test/java/com/microsoft/azure/servicebus/jms/aad/QueueTest.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/aad/QueueTest.java
@@ -1,6 +1,6 @@
 package com.microsoft.azure.servicebus.jms.aad;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 
 public class QueueTest {

--- a/src/test/java/com/microsoft/azure/servicebus/jms/aad/TestInitialization.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/aad/TestInitialization.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.azure.servicebus.jms.aad;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/microsoft/azure/servicebus/jms/aad/TopicTest.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/aad/TopicTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 package com.microsoft.azure.servicebus.jms.aad;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.azure.identity.DefaultAzureCredentialBuilder;
 

--- a/src/test/java/com/microsoft/azure/servicebus/jms/connection/string/QueueTests.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/connection/string/QueueTests.java
@@ -2,7 +2,7 @@
 package com.microsoft.azure.servicebus.jms.connection.string;
 
 import javax.jms.TextMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.microsoft.azure.servicebus.jms.aad.TestInitialization;
 
 public class QueueTests {	

--- a/src/test/java/com/microsoft/azure/servicebus/jms/connection/string/TopicTests.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/connection/string/TopicTests.java
@@ -1,6 +1,6 @@
 package com.microsoft.azure.servicebus.jms.connection.string;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.microsoft.azure.servicebus.jms.aad.TestInitialization;
 
 public class TopicTests {	

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/ConfigurationOptionsTest.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/ConfigurationOptionsTest.java
@@ -1,13 +1,14 @@
 package com.microsoft.azure.servicebus.jms.jndi;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.jms.Connection;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.servicebus.jms.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
@@ -17,7 +18,7 @@ import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings
 public class ConfigurationOptionsTest {
     ConnectionStringBuilder connectionStringBuilder;
     
-    @Before
+    @BeforeEach
     public void testInitialize() {
         connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
     }

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/JNDIConnectionFactoryTests.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/JNDIConnectionFactoryTests.java
@@ -3,15 +3,12 @@
 
 package com.microsoft.azure.servicebus.jms.jndi;
 
-
-import static org.junit.Assert.assertNotNull;
-
-import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import javax.jms.*;
 import javax.naming.Reference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
 import com.microsoft.azure.servicebus.jms.ConnectionStringBuilder;

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/JNDIQueueTests.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/JNDIQueueTests.java
@@ -3,8 +3,8 @@
 
 package com.microsoft.azure.servicebus.jms.jndi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.UUID;
 
@@ -22,8 +22,8 @@ import javax.jms.QueueSession;
 import javax.jms.Session;
 import javax.naming.Reference;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
 import com.microsoft.azure.servicebus.jms.ServiceBusJmsQueueConnectionFactory;
@@ -34,7 +34,7 @@ public class JNDIQueueTests {
     ServiceBusJmsQueueConnectionFactory sbQueueConnectionFactory;
     String queueName;
 
-    @Before
+    @BeforeEach
     public void testInitialize() {
         ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
         sbConnectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, null);

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/JNDITopicTests.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/JNDITopicTests.java
@@ -3,8 +3,8 @@
 
 package com.microsoft.azure.servicebus.jms.jndi;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.UUID;
 
 import javax.jms.Connection;
@@ -20,8 +20,8 @@ import javax.jms.TopicSession;
 import javax.jms.Session;
 import javax.naming.Reference;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
 import com.microsoft.azure.servicebus.jms.ServiceBusJmsTopic;
@@ -33,7 +33,7 @@ public class JNDITopicTests {
     ServiceBusJmsTopicConnectionFactory sbTopicConnectionFactory;
     String topicName;
 
-    @Before
+    @BeforeEach
     public void testInitialize() {
         ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
         sbConnectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, null);

--- a/src/test/java/com/microsoft/azure/servicebus/jms/jndi/TestUtils.java
+++ b/src/test/java/com/microsoft/azure/servicebus/jms/jndi/TestUtils.java
@@ -3,8 +3,8 @@
 
 package com.microsoft.azure.servicebus.jms.jndi;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import javax.naming.NamingException;
 import javax.naming.Reference;


### PR DESCRIPTION
The qpid.jms.client has been updated to the highest version that still supports the javax.jms namespace. 

### Updating to newest version
- maven-plugin-plugin 3.11.0
- qpid-jms-client 1.11.0
- azure-identity 1.11.2

### Add
- junit 5.10.2
- jakarta.jms-api 2.0.3

### Remove
- geronimo-jms_2.0_spec
- junit 4