### PR TITLE
Fix query parameters when forming the RemoteConnectionURI so factory can be created correctly with the intended options.

### DIFF
--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactorySettings.java
@@ -314,16 +314,23 @@ public class ServiceBusJmsConnectionFactorySettings {
         this.reconnectAmqpOpenServerListAction = amqpOpenServerListAction;
     }
     
-    String getServiceBusQuery() {
+    String getPerHostAmqpProviderQuery()
+    {
         StringBuilder builder = new StringBuilder();
-        if (connectionIdleTimeoutMS > 0) {
-            appendQuery(builder, "amqp.idleTimeout", String.valueOf(connectionIdleTimeoutMS));
+        if (this.connectionIdleTimeoutMS > 0) {
+            StringUtil.appendQuery(builder, "amqp.idleTimeout", String.valueOf(this.connectionIdleTimeoutMS));
         }
         
-        if (traceFrames) {
-            appendQuery(builder, "amqp.traceFrames", "true");
+        if (this.traceFrames) {
+            StringUtil.appendQuery(builder, "amqp.traceFrames", "true");
         }
         
+        return builder.toString();
+    }
+
+    String getGlobalJMSProviderQuery() {
+        StringBuilder builder = new StringBuilder();
+
         if (this.configurationOptions == null) {
             this.configurationOptions = new HashMap<>();
         }
@@ -333,66 +340,58 @@ public class ServiceBusJmsConnectionFactorySettings {
         for (String defaultOption : DefaultConfigurationOptions.keySet()) {
             configurationOptions.putIfAbsent(defaultOption, DefaultConfigurationOptions.get(defaultOption));
         }
-        
+
         for (String option : configurationOptions.keySet()) {
-            appendQuery(builder, option, configurationOptions.get(option));
+             StringUtil.appendQuery(builder, option, configurationOptions.get(option));
         }
         
         return builder.toString();
     }
     
-    String getReconnectQuery() {
+    String getGlobalFailoverProviderQuery() {
         StringBuilder queryBuilder = new StringBuilder();
         
         if (initialReconnectDelay != null) {
-            appendQuery(queryBuilder, "failover.initialReconnectDelay", String.valueOf(initialReconnectDelay));
+            StringUtil.appendQuery(queryBuilder, "failover.initialReconnectDelay", String.valueOf(initialReconnectDelay));
         }
         
         if (reconnectDelay != null) {
-            appendQuery(queryBuilder, "failover.reconnectDelay", String.valueOf(reconnectDelay));
+            StringUtil.appendQuery(queryBuilder, "failover.reconnectDelay", String.valueOf(reconnectDelay));
         }
         
         if (maxReconnectDelay != null) {
-            appendQuery(queryBuilder, "failover.maxReconnectDelay", String.valueOf(maxReconnectDelay));
+            StringUtil.appendQuery(queryBuilder, "failover.maxReconnectDelay", String.valueOf(maxReconnectDelay));
         }
         
         if (useReconnectBackOff != null) {
-            appendQuery(queryBuilder, "failover.useReconnectBackOff", String.valueOf(useReconnectBackOff));
+            StringUtil.appendQuery(queryBuilder, "failover.useReconnectBackOff", String.valueOf(useReconnectBackOff));
         }
         
         if (reconnectBackOffMultiplier != null) {
-            appendQuery(queryBuilder, "failover.reconnectBackOffMultiplier", String.valueOf(reconnectBackOffMultiplier));
+            StringUtil.appendQuery(queryBuilder, "failover.reconnectBackOffMultiplier", String.valueOf(reconnectBackOffMultiplier));
         }
         
         if (maxReconnectAttempts != null) {
-            appendQuery(queryBuilder, "failover.maxReconnectAttempts", String.valueOf(maxReconnectAttempts));
+            StringUtil.appendQuery(queryBuilder, "failover.maxReconnectAttempts", String.valueOf(maxReconnectAttempts));
         }
         
         if (startupMaxReconnectAttempts != null) {
-            appendQuery(queryBuilder, "failover.startupMaxReconnectAttempts", String.valueOf(startupMaxReconnectAttempts));
+            StringUtil.appendQuery(queryBuilder, "failover.startupMaxReconnectAttempts", String.valueOf(startupMaxReconnectAttempts));
         }
         
         if (warnAfterReconnectAttempts != null) {
-            appendQuery(queryBuilder, "failover.warnAfterReconnectAttempts", String.valueOf(warnAfterReconnectAttempts));
+            StringUtil.appendQuery(queryBuilder, "failover.warnAfterReconnectAttempts", String.valueOf(warnAfterReconnectAttempts));
         }
 
         if (reconnectRandomize != null) {
-            appendQuery(queryBuilder, "failover.randomize", String.valueOf(reconnectRandomize));
+            StringUtil.appendQuery(queryBuilder, "failover.randomize", String.valueOf(reconnectRandomize));
         }
         
         if (reconnectAmqpOpenServerListAction != null) {
-            appendQuery(queryBuilder, "failover.amqpOpenServerListAction", reconnectAmqpOpenServerListAction.name());
+            StringUtil.appendQuery(queryBuilder, "failover.amqpOpenServerListAction", reconnectAmqpOpenServerListAction.name());
         }
         
         return queryBuilder.toString();
-    }
-    
-    private void appendQuery(StringBuilder builder, String key, String value) {
-        if (builder == null) {
-            builder = new StringBuilder();
-        }
-        
-        builder.append((builder.length() == 0) ? "?" : "&").append(key).append("=").append(value);
     }
     
     private static Map<String, String> getDefaultConfigurationOptions() {

--- a/src/main/java/com/azure/servicebus/jms/StringUtil.java
+++ b/src/main/java/com/azure/servicebus/jms/StringUtil.java
@@ -29,6 +29,14 @@ public final class StringUtil {
         return true;
     }
 
+    public static void appendQuery(StringBuilder builder, String key, String value) {
+        if (builder == null) {
+            builder = new StringBuilder();
+        }
+
+        builder.append((builder.length() == 0) ? "" : "&").append(key).append("=").append(value);
+    }
+
     public static String getShortRandomString() {
         return getRandomString().substring(0, 6);
     }

--- a/src/test/java/com/azure/servicebus/jms/aad/TestInitialization.java
+++ b/src/test/java/com/azure/servicebus/jms/aad/TestInitialization.java
@@ -74,6 +74,8 @@ public class TestInitialization
         // Common
         this.HOST = System.getenv("HOST_NAMESPACE");
         this.SETTINGS = new ServiceBusJmsConnectionFactorySettings();
+        // Setting this just to make sure when these options are specified the URI and factory gets formed correctly.
+        this.SETTINGS.setConnectionIdleTimeoutMS(62000);
         this.entityName = entityName;
 	}
 	

--- a/src/test/java/com/azure/servicebus/jms/connection/string/ServiceBusJMSConnectionFactoryUriBuilderTest.java
+++ b/src/test/java/com/azure/servicebus/jms/connection/string/ServiceBusJMSConnectionFactoryUriBuilderTest.java
@@ -1,0 +1,169 @@
+package com.azure.servicebus.jms.connection.string;
+
+import com.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+import com.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.qpid.jms.policy.JmsDefaultPrefetchPolicy;
+import org.junit.jupiter.api.Test;
+
+public class ServiceBusJMSConnectionFactoryUriBuilderTest {
+
+	@Test
+	public void testSingleHostNoOptions() {
+		Map<String, String> configurationOptions = new HashMap<>();
+		configurationOptions.put("jms.prefetchPolicy.all", "20");
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(
+				configurationOptions);
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		// Passing no options but failover is true by default
+		String expectedUri = "failover:(amqps://foo.servicebus.windows.net)?jms.prefetchPolicy.all=20";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testSingleHostWithJmsPrefetch() {
+		Map<String, String> configurationOptions = new HashMap<>();
+		configurationOptions.put("jms.prefetchPolicy.all", "20");
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(
+				configurationOptions);
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		// Passing no options but failover is true by default
+		String expectedUri = "failover:(amqps://foo.servicebus.windows.net)?jms.prefetchPolicy.all=20";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+		JmsDefaultPrefetchPolicy prefetchPolicy = (JmsDefaultPrefetchPolicy) factory.getPrefetchPolicy();
+		assertEquals(20, prefetchPolicy.getQueuePrefetch());
+	}
+
+	@Test
+	public void testSingleHostNoOptionsWithoutDefaultReconnect() {
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings();
+		settings.setShouldReconnect(false);
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		// Passing no options with reconnect disabled.
+		String expectedUri = "amqps://foo.servicebus.windows.net?jms.prefetchPolicy.all=0";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testSingleHostNoOptionsWithoutDefaultReconnectWithJMSPrefetch() {
+		Map<String, String> configurationOptions = new HashMap<>();
+		configurationOptions.put("jms.prefetchPolicy.all", "20");
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(
+				configurationOptions);
+		settings.setShouldReconnect(false);
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		// Passing no options with reconnect disabled.
+		String expectedUri = "amqps://foo.servicebus.windows.net?jms.prefetchPolicy.all=20";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testSingleHostWithAmqpOptionsWithDefaultReconnect() {
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings();
+		settings.setConnectionIdleTimeoutMS(20000);
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		String expectedUri = "failover:(amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000)?jms.prefetchPolicy.all=0";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testSingleHostWithAmqpOptionsWithoutDefaultReconnect() {
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings();
+		settings.setShouldReconnect(false);
+		settings.setConnectionIdleTimeoutMS(20000);
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		String expectedUri = "amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000&jms.prefetchPolicy.all=0";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testSingleHostWithAmqpOptionsWithDefaultReconnectAndFailoverOptions() {
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings();
+		settings.setConnectionIdleTimeoutMS(20000);
+		settings.setMaxReconnectAttempts(3);
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		String expectedUri = "failover:(amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000)?failover.maxReconnectAttempts=3&jms.prefetchPolicy.all=0";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testMultipleHostsWithAmqpOptionsWithDefaultReconnectAndFailoverOptions() {
+		String host = "foo.servicebus.windows.net";
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings();
+		settings.setMaxReconnectAttempts(3);
+		settings.setConnectionIdleTimeoutMS(20000);
+		String[] reconnectHosts = { "bar.servicebus.windows.net" };
+		settings.setReconnectHosts(reconnectHosts);
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		String expectedUri = "failover:(amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000,amqps://bar.servicebus.windows.net?amqp.idleTimeout=20000)?failover.maxReconnectAttempts=3&jms.prefetchPolicy.all=0";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+	}
+
+	@Test
+	public void testMultipleHostsWithJustJMSPrefetech() {
+		String host = "foo.servicebus.windows.net";
+		Map<String, String> configurationOptions = new HashMap<>();
+		configurationOptions.put("jms.prefetchPolicy.all", "20");
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(
+				configurationOptions);
+		String[] reconnectHosts = { "bar.servicebus.windows.net" };
+		settings.setReconnectHosts(reconnectHosts);
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		String expectedUri = "failover:(amqps://foo.servicebus.windows.net,amqps://bar.servicebus.windows.net)?jms.prefetchPolicy.all=20";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+		JmsDefaultPrefetchPolicy prefetchPolicy = (JmsDefaultPrefetchPolicy) factory.getPrefetchPolicy();
+		assertEquals(20, prefetchPolicy.getQueuePrefetch());
+	}
+
+	@Test
+	public void testMultipleHostsWithAmqpOptionsWithoutDefaultReconnectAndFailoverOptions() {
+		String host = "foo.servicebus.windows.net";
+		Map<String, String> configurationOptions = new HashMap<>();
+		configurationOptions.put("jms.prefetchPolicy.all", "20");
+		ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings(
+				configurationOptions);
+		settings.setShouldReconnect(false);
+		settings.setConnectionIdleTimeoutMS(20000);
+		// Even though options like maxReconnectAttempts and reconnect hosts are
+		// specified, since reconnect is set to false, there should be no failover
+		// options
+		// added and only AmqpOptions and JMSProviderOptions should be formed.
+		settings.setMaxReconnectAttempts(3);
+		String[] reconnectHosts = { "bar.servicebus.windows.net" };
+		settings.setReconnectHosts(reconnectHosts);
+		ServiceBusJmsConnectionFactory factory = new ServiceBusJmsConnectionFactory("user", "pass", host, settings);
+
+		String expectedUri = "amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000&jms.prefetchPolicy.all=20";
+		String actualUri = factory.getRemoteConnectionUri();
+		assertEquals(expectedUri, actualUri);
+		JmsDefaultPrefetchPolicy prefetchPolicy = (JmsDefaultPrefetchPolicy) factory.getPrefetchPolicy();
+		assertEquals(20, prefetchPolicy.getQueuePrefetch());
+	}
+}


### PR DESCRIPTION
There were bugs when we were forming the RemoteConnectionURI with some query options specified. The Query options is then passed to the provider when forming the factory, so if the query options are not passed correctly, then the factory is created with unintended options.

For ex, the following URI was being formed when amqp.idleTimeout option was specified:

1.failover:(amqps://testperfprodvinsu.servicebus.windows.net)?failover.initialReconnectDelay=30000?amqp.idleTimeout=62000&jms.prefetchPolicy.all=0

The amqp.idleTimeout is only used when it's passed along with the host, so the correct URI should be:

failover:(amqps://testperfprodvinsu.servicebus.windows.net?amqp.idleTimeout=20000)?failover.initialReconnectDelay=30000&jms.prefetchPolicy.all=20

2. When failover options are specified, the query part is built incorrectly with two question marks:
failover:(amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000)?failover.maxReconnectAttempts=3?jms.prefetchPolicy.all=0

Instead of:
failover:(amqps://foo.servicebus.windows.net?amqp.idleTimeout=20000)?failover.maxReconnectAttempts=3&jms.prefetchPolicy.all=0

3. If User turns of reconnect, then again the URI was being formed incorrectly with multiple question marks in the query part. 

All of the above problems have been fixed the current PR and tests have been added in the 'ServiceBusJMSConnectionFactoryUriBuilderTest' to ensure the correct URI is being formed when creating the factory.
