### PR TITLE
Address issue where Spring JMS CachingConnectionFactory is not caching Producers or Consumers

### DIFF
--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsQueue.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsQueue.java
@@ -61,4 +61,41 @@ public final class ServiceBusJmsQueue extends JNDIStorable implements Queue {
         JmsQueue innerQueue = new JmsQueue(name);
         this.innerQueue = innerQueue;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ServiceBusJmsQueue that = (ServiceBusJmsQueue) obj;
+        try {
+            String thisQueueName = this.getQueueName();
+            String thatQueueName = that.getQueueName();
+            return thisQueueName != null ? thisQueueName.equals(thatQueueName) : thatQueueName == null;
+        } catch (JMSException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        try {
+            String queueName = this.getQueueName();
+            return queueName != null ? queueName.hashCode() : 0;
+        } catch (JMSException e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return "ServiceBusJmsQueue{queueName='" + this.getQueueName() + "'}";
+        } catch (JMSException e) {
+            return "ServiceBusJmsQueue{queueName=<error: " + e.getMessage() + ">}";
+        }
+    }
 }

--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsTopic.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsTopic.java
@@ -60,4 +60,41 @@ public final class ServiceBusJmsTopic extends JNDIStorable implements Topic {
         JmsTopic innerTopic = new JmsTopic(name);
         this.innerTopic = innerTopic;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ServiceBusJmsTopic that = (ServiceBusJmsTopic) obj;
+        try {
+            String thisTopicName = this.getTopicName();
+            String thatTopicName = that.getTopicName();
+            return thisTopicName != null ? thisTopicName.equals(thatTopicName) : thatTopicName == null;
+        } catch (JMSException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        try {
+            String topicName = this.getTopicName();
+            return topicName != null ? topicName.hashCode() : 0;
+        } catch (JMSException e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return "ServiceBusJmsTopic{topicName='" + this.getTopicName() + "'}";
+        } catch (JMSException e) {
+            return "ServiceBusJmsTopic{topicName=<error: " + e.getMessage() + ">}";
+        }
+    }
 }

--- a/src/test/java/com/azure/servicebus/jms/ServiceBusJmsDestinationEqualsHashCodeUnitTest.java
+++ b/src/test/java/com/azure/servicebus/jms/ServiceBusJmsDestinationEqualsHashCodeUnitTest.java
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package com.azure.servicebus.jms;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.apache.qpid.jms.JmsQueue;
+import org.apache.qpid.jms.JmsTopic;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unit tests for equals, hashCode, and toString methods of ServiceBusJmsQueue and ServiceBusJmsTopic
+ * These tests don't require actual Service Bus connections.
+ */
+public class ServiceBusJmsDestinationEqualsHashCodeUnitTest {
+    
+    private static final String QUEUE_NAME = "test-queue";
+    private static final String TOPIC_NAME = "test-topic";
+    private static final String DIFFERENT_QUEUE_NAME = "different-queue";
+    private static final String DIFFERENT_TOPIC_NAME = "different-topic";
+
+    @Test
+    public void testServiceBusJmsQueueEquality() {
+        // Create ServiceBusJmsQueue instances with same queue name
+        ServiceBusJmsQueue queue1 = new ServiceBusJmsQueue(new JmsQueue(QUEUE_NAME));
+        ServiceBusJmsQueue queue2 = new ServiceBusJmsQueue(new JmsQueue(QUEUE_NAME));
+        
+        // Test equality
+        assertEquals(queue1, queue2);
+        assertEquals(queue2, queue1);
+        assertEquals(queue1, queue1); // reflexivity
+        
+        // Create queue with different name
+        ServiceBusJmsQueue differentQueue = new ServiceBusJmsQueue(new JmsQueue(DIFFERENT_QUEUE_NAME));
+        assertNotEquals(queue1, differentQueue);
+        assertNotEquals(differentQueue, queue1);
+    }
+
+    @Test
+    public void testServiceBusJmsQueueHashCode() {
+        // Create ServiceBusJmsQueue instances with same queue name
+        ServiceBusJmsQueue queue1 = new ServiceBusJmsQueue(new JmsQueue(QUEUE_NAME));
+        ServiceBusJmsQueue queue2 = new ServiceBusJmsQueue(new JmsQueue(QUEUE_NAME));
+        
+        // Hash codes should be equal for equal objects
+        assertEquals(queue1.hashCode(), queue2.hashCode());
+        
+        // Test with different queue name
+        ServiceBusJmsQueue differentQueue = new ServiceBusJmsQueue(new JmsQueue(DIFFERENT_QUEUE_NAME));
+        // Different objects may have different hash codes (not required but likely)
+        assertNotEquals(queue1.hashCode(), differentQueue.hashCode());
+    }
+
+    @Test
+    public void testServiceBusJmsQueueToString() {
+        ServiceBusJmsQueue queue = new ServiceBusJmsQueue(new JmsQueue(QUEUE_NAME));
+        String toString = queue.toString();
+        
+        // toString should contain the queue name and class name
+        assertTrue(toString.contains(QUEUE_NAME));
+        assertTrue(toString.contains("ServiceBusJmsQueue"));
+        
+        // toString should be consistent
+        assertEquals(toString, queue.toString());
+    }
+
+    @Test
+    public void testServiceBusJmsTopicHashCode() {
+        // Create ServiceBusJmsTopic instances with same topic name
+        ServiceBusJmsTopic topic1 = new ServiceBusJmsTopic(new JmsTopic(TOPIC_NAME));
+        ServiceBusJmsTopic topic2 = new ServiceBusJmsTopic(new JmsTopic(TOPIC_NAME));
+        
+        // Hash codes should be equal for equal objects
+        assertEquals(topic1.hashCode(), topic2.hashCode());
+        
+        // Test with different topic name
+        ServiceBusJmsTopic differentTopic = new ServiceBusJmsTopic(new JmsTopic(DIFFERENT_TOPIC_NAME));
+        // Different objects may have different hash codes (not required but likely)
+        assertNotEquals(topic1.hashCode(), differentTopic.hashCode());
+    }
+
+    @Test
+    public void testServiceBusJmsTopicToString() {
+        ServiceBusJmsTopic topic = new ServiceBusJmsTopic(new JmsTopic(TOPIC_NAME));
+        String toString = topic.toString();
+        
+        // toString should contain the topic name and class name
+        assertTrue(toString.contains(TOPIC_NAME));
+        assertTrue(toString.contains("ServiceBusJmsTopic"));
+        
+        // toString should be consistent
+        assertEquals(toString, topic.toString());
+    }
+
+    @Test
+    public void testNullSafety() {
+        ServiceBusJmsQueue queue = new ServiceBusJmsQueue(new JmsQueue(QUEUE_NAME));
+        ServiceBusJmsTopic topic = new ServiceBusJmsTopic(new JmsTopic(TOPIC_NAME));
+        
+        // Should not equal null
+        assertNotEquals(queue, null);
+        assertNotEquals(topic, null);
+        
+        // Should not equal objects of different types
+        assertNotEquals(queue, "string");
+        assertNotEquals(topic, "string");
+        assertNotEquals(queue, topic);
+    }
+}

--- a/src/test/java/com/azure/servicebus/jms/ServiceBusJmsQueueEqualsHashCodeTest.java
+++ b/src/test/java/com/azure/servicebus/jms/ServiceBusJmsQueueEqualsHashCodeTest.java
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package com.azure.servicebus.jms;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.jms.Connection;
+import jakarta.jms.Session;
+import jakarta.jms.Queue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.azure.servicebus.jms.jndi.TestUtils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ServiceBusJmsQueueEqualsHashCodeTest {
+    private ServiceBusJmsConnectionFactory connectionFactory;
+    private static final String QUEUE_NAME = "test-queue";
+    private static final String DIFFERENT_QUEUE_NAME = "different-queue";
+
+    @BeforeEach
+    public void setUp() {
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
+        connectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, null);
+    }
+
+    @Test
+    public void testQueueEquality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create two queues with the same name
+            Queue queue1 = session.createQueue(QUEUE_NAME);
+            Queue queue2 = session.createQueue(QUEUE_NAME);
+            
+            // They should be equal
+            assertEquals(queue1, queue2);
+            assertEquals(queue2, queue1);
+            
+            // Reflexivity
+            assertEquals(queue1, queue1);
+            
+            // Create a queue with different name
+            Queue differentQueue = session.createQueue(DIFFERENT_QUEUE_NAME);
+            
+            // They should not be equal
+            assertNotEquals(queue1, differentQueue);
+            assertNotEquals(differentQueue, queue1);
+        }
+    }
+
+    @Test
+    public void testQueueHashCode() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create two queues with the same name
+            Queue queue1 = session.createQueue(QUEUE_NAME);
+            Queue queue2 = session.createQueue(QUEUE_NAME);
+            
+            // They should have the same hash code
+            assertEquals(queue1.hashCode(), queue2.hashCode());
+            
+            // Create a queue with different name
+            Queue differentQueue = session.createQueue(DIFFERENT_QUEUE_NAME);
+            
+            // Different queues may have different hash codes (not required, but likely)
+            // We don't assert inequality here as hash collisions are allowed
+        }
+    }
+
+    @Test
+    public void testQueueToString() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Queue queue = session.createQueue(QUEUE_NAME);
+            String toString = queue.toString();
+            
+            // toString should contain the queue name
+            assertTrue(toString.contains(QUEUE_NAME));
+            assertTrue(toString.contains("ServiceBusJmsQueue"));
+            
+            // toString should be consistent
+            assertEquals(toString, queue.toString());
+        }
+    }
+
+    @Test
+    public void testNullEquality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Queue queue = session.createQueue(QUEUE_NAME);
+            
+            // Queue should not equal null
+            assertNotEquals(queue, null);
+            assertNotEquals(null, queue);
+        }
+    }
+
+    @Test
+    public void testDifferentClassEquality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Queue queue = session.createQueue(QUEUE_NAME);
+            String string = "not a queue";
+            
+            // Queue should not equal object of different class
+            assertNotEquals(queue, string);
+        }
+    }
+
+    @Test
+    public void testSpringCachingSimulation() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Simulate Spring's CachingConnectionFactory behavior
+            Map<Queue, String> producerCache = new HashMap<>();
+            
+            // Create multiple queue instances with same name
+            Queue queue1 = session.createQueue(QUEUE_NAME);
+            Queue queue2 = session.createQueue(QUEUE_NAME);
+            Queue queue3 = session.createQueue(QUEUE_NAME);
+            
+            // Simulate caching producers
+            producerCache.put(queue1, "producer1");
+            
+            // All instances should retrieve the same cached producer
+            assertEquals("producer1", producerCache.get(queue1));
+            assertEquals("producer1", producerCache.get(queue2));
+            assertEquals("producer1", producerCache.get(queue3));
+            
+            // Cache should only contain one entry
+            assertEquals(1, producerCache.size());
+        }
+    }
+}

--- a/src/test/java/com/azure/servicebus/jms/ServiceBusJmsTopicEqualsHashCodeTest.java
+++ b/src/test/java/com/azure/servicebus/jms/ServiceBusJmsTopicEqualsHashCodeTest.java
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package com.azure.servicebus.jms;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.jms.Connection;
+import jakarta.jms.Session;
+import jakarta.jms.Topic;
+import jakarta.jms.Queue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.azure.servicebus.jms.jndi.TestUtils;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ServiceBusJmsTopicEqualsHashCodeTest {
+    private ServiceBusJmsConnectionFactory connectionFactory;
+    private static final String TOPIC_NAME = "test-topic";
+    private static final String DIFFERENT_TOPIC_NAME = "different-topic";
+
+    @BeforeEach
+    public void setUp() {
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
+        connectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, null);
+    }
+
+    @Test
+    public void testTopicEquality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create two topics with the same name
+            Topic topic1 = session.createTopic(TOPIC_NAME);
+            Topic topic2 = session.createTopic(TOPIC_NAME);
+            
+            // They should be equal
+            assertEquals(topic1, topic2);
+            assertEquals(topic2, topic1);
+            
+            // Reflexivity
+            assertEquals(topic1, topic1);
+            
+            // Create a topic with different name
+            Topic differentTopic = session.createTopic(DIFFERENT_TOPIC_NAME);
+            
+            // They should not be equal
+            assertNotEquals(topic1, differentTopic);
+            assertNotEquals(differentTopic, topic1);
+        }
+    }
+
+    @Test
+    public void testTopicHashCode() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create two topics with the same name
+            Topic topic1 = session.createTopic(TOPIC_NAME);
+            Topic topic2 = session.createTopic(TOPIC_NAME);
+            
+            // They should have the same hash code
+            assertEquals(topic1.hashCode(), topic2.hashCode());
+            
+            // Create a topic with different name
+            Topic differentTopic = session.createTopic(DIFFERENT_TOPIC_NAME);
+            
+            // Different topics may have different hash codes (not required, but likely)
+            // We don't assert inequality here as hash collisions are allowed
+        }
+    }
+
+    @Test
+    public void testTopicToString() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Topic topic = session.createTopic(TOPIC_NAME);
+            String toString = topic.toString();
+            
+            // toString should contain the topic name
+            assertTrue(toString.contains(TOPIC_NAME));
+            assertTrue(toString.contains("ServiceBusJmsTopic"));
+            
+            // toString should be consistent
+            assertEquals(toString, topic.toString());
+        }
+    }
+
+    @Test
+    public void testNullEquality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Topic topic = session.createTopic(TOPIC_NAME);
+            
+            // Topic should not equal null
+            assertNotEquals(topic, null);
+            assertNotEquals(null, topic);
+        }
+    }
+
+    @Test
+    public void testDifferentClassEquality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Topic topic = session.createTopic(TOPIC_NAME);
+            String string = "not a topic";
+            
+            // Topic should not equal object of different class
+            assertNotEquals(topic, string);
+        }
+    }
+
+    @Test
+    public void testSpringCachingSimulation() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Simulate Spring's CachingConnectionFactory behavior
+            Map<Topic, String> producerCache = new HashMap<>();
+            
+            // Create multiple topic instances with same name
+            Topic topic1 = session.createTopic(TOPIC_NAME);
+            Topic topic2 = session.createTopic(TOPIC_NAME);
+            Topic topic3 = session.createTopic(TOPIC_NAME);
+            
+            // Simulate caching producers
+            producerCache.put(topic1, "producer1");
+            
+            // All instances should retrieve the same cached producer
+            assertEquals("producer1", producerCache.get(topic1));
+            assertEquals("producer1", producerCache.get(topic2));
+            assertEquals("producer1", producerCache.get(topic3));
+            
+            // Cache should only contain one entry
+            assertEquals(1, producerCache.size());
+        }
+    }
+
+    @Test
+    public void testQueueTopicInequality() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create a topic and queue with the same name
+            Topic topic = session.createTopic(TOPIC_NAME);
+            Queue queue = session.createQueue(TOPIC_NAME); // Same name but different type
+            
+            // They should not be equal even with the same name
+            assertNotEquals(topic, queue);
+            assertNotEquals(queue, topic);
+        }
+    }
+}

--- a/src/test/java/com/azure/servicebus/jms/SpringCachingBehaviorTest.java
+++ b/src/test/java/com/azure/servicebus/jms/SpringCachingBehaviorTest.java
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package com.azure.servicebus.jms;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.jms.Connection;
+import jakarta.jms.Destination;
+import jakarta.jms.Session;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.azure.servicebus.jms.jndi.TestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Integration test that simulates Spring's CachingConnectionFactory behavior
+ * to verify that ServiceBusJmsQueue and ServiceBusJmsTopic properly support
+ * producer caching through correct equals() and hashCode() implementations.
+ */
+public class SpringCachingBehaviorTest {
+    private ServiceBusJmsConnectionFactory connectionFactory;
+    private static final String QUEUE_NAME = "test-cache-queue";
+    private static final String TOPIC_NAME = "test-cache-topic";
+
+    @BeforeEach
+    public void setUp() {
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(TestUtils.TEST_CONNECTION_STRING);
+        connectionFactory = new ServiceBusJmsConnectionFactory(connectionStringBuilder, null);
+    }
+
+    /**
+     * Simulates Spring's DestinationCacheKey behavior for queues
+     */
+    @Test
+    public void testQueueDestinationCacheKeyBehavior() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create multiple queue instances with same name (simulating different session calls)
+            Queue queue1 = session.createQueue(QUEUE_NAME);
+            Queue queue2 = session.createQueue(QUEUE_NAME);
+            Queue queue3 = session.createQueue(QUEUE_NAME);
+            
+            // Simulate Spring's DestinationCacheKey creation and caching
+            DestinationCacheKey key1 = new DestinationCacheKey(queue1);
+            DestinationCacheKey key2 = new DestinationCacheKey(queue2);
+            DestinationCacheKey key3 = new DestinationCacheKey(queue3);
+            
+            // All cache keys should be equal
+            assertEquals(key1, key2);
+            assertEquals(key2, key3);
+            assertEquals(key1, key3);
+            
+            // All cache keys should have the same hash code
+            assertEquals(key1.hashCode(), key2.hashCode());
+            assertEquals(key2.hashCode(), key3.hashCode());
+            
+            // Simulate the producer cache
+            Map<DestinationCacheKey, String> producerCache = new HashMap<>();
+            producerCache.put(key1, "cached-producer-1");
+            
+            // All keys should retrieve the same cached producer
+            assertEquals("cached-producer-1", producerCache.get(key1));
+            assertEquals("cached-producer-1", producerCache.get(key2));
+            assertEquals("cached-producer-1", producerCache.get(key3));
+            
+            // Cache should only contain one entry
+            assertEquals(1, producerCache.size());
+        }
+    }
+
+    /**
+     * Simulates Spring's DestinationCacheKey behavior for topics
+     */
+    @Test
+    public void testTopicDestinationCacheKeyBehavior() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            // Create multiple topic instances with same name (simulating different session calls)
+            Topic topic1 = session.createTopic(TOPIC_NAME);
+            Topic topic2 = session.createTopic(TOPIC_NAME);
+            Topic topic3 = session.createTopic(TOPIC_NAME);
+            
+            // Simulate Spring's DestinationCacheKey creation and caching
+            DestinationCacheKey key1 = new DestinationCacheKey(topic1);
+            DestinationCacheKey key2 = new DestinationCacheKey(topic2);
+            DestinationCacheKey key3 = new DestinationCacheKey(topic3);
+            
+            // All cache keys should be equal
+            assertEquals(key1, key2);
+            assertEquals(key2, key3);
+            assertEquals(key1, key3);
+            
+            // All cache keys should have the same hash code
+            assertEquals(key1.hashCode(), key2.hashCode());
+            assertEquals(key2.hashCode(), key3.hashCode());
+            
+            // Simulate the producer cache
+            Map<DestinationCacheKey, String> producerCache = new HashMap<>();
+            producerCache.put(key1, "cached-producer-1");
+            
+            // All keys should retrieve the same cached producer
+            assertEquals("cached-producer-1", producerCache.get(key1));
+            assertEquals("cached-producer-1", producerCache.get(key2));
+            assertEquals("cached-producer-1", producerCache.get(key3));
+            
+            // Cache should only contain one entry
+            assertEquals(1, producerCache.size());
+        }
+    }
+
+    /**
+     * Tests that different destinations (different names) create different cache keys
+     */
+    @Test
+    public void testDifferentDestinationsCreateDifferentCacheKeys() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Queue queue1 = session.createQueue("queue-1");
+            Queue queue2 = session.createQueue("queue-2");
+            Topic topic1 = session.createTopic("topic-1");
+            Topic topic2 = session.createTopic("topic-2");
+            
+            DestinationCacheKey queueKey1 = new DestinationCacheKey(queue1);
+            DestinationCacheKey queueKey2 = new DestinationCacheKey(queue2);
+            DestinationCacheKey topicKey1 = new DestinationCacheKey(topic1);
+            DestinationCacheKey topicKey2 = new DestinationCacheKey(topic2);
+            
+            // Different destinations should create different cache keys
+            assertNotEquals(queueKey1, queueKey2);
+            assertNotEquals(topicKey1, topicKey2);
+            assertNotEquals(queueKey1, topicKey1);
+            
+            // Test caching behavior
+            Map<DestinationCacheKey, String> producerCache = new HashMap<>();
+            producerCache.put(queueKey1, "queue-1-producer");
+            producerCache.put(queueKey2, "queue-2-producer");
+            producerCache.put(topicKey1, "topic-1-producer");
+            producerCache.put(topicKey2, "topic-2-producer");
+            
+            assertEquals(4, producerCache.size());
+            assertEquals("queue-1-producer", producerCache.get(queueKey1));
+            assertEquals("queue-2-producer", producerCache.get(queueKey2));
+            assertEquals("topic-1-producer", producerCache.get(topicKey1));
+            assertEquals("topic-2-producer", producerCache.get(topicKey2));
+        }
+    }
+
+    /**
+     * Tests the toString() behavior for debugging purposes
+     */
+    @Test
+    public void testToStringForDebugging() throws Exception {
+        try (Connection connection = connectionFactory.createConnection();
+             Session session = connection.createSession()) {
+            
+            Queue queue = session.createQueue(QUEUE_NAME);
+            Topic topic = session.createTopic(TOPIC_NAME);
+            
+            String queueString = queue.toString();
+            String topicString = topic.toString();
+            
+            // toString should contain meaningful information
+            assertTrue(queueString.contains("ServiceBusJmsQueue"));
+            assertTrue(queueString.contains(QUEUE_NAME));
+            
+            assertTrue(topicString.contains("ServiceBusJmsTopic"));
+            assertTrue(topicString.contains(TOPIC_NAME));
+            
+            // Different destinations should have different string representations
+            assertNotEquals(queueString, topicString);
+        }
+    }
+
+    /**
+     * Simplified DestinationCacheKey implementation to simulate Spring's behavior
+     */
+    private static class DestinationCacheKey {
+        private final Destination destination;
+
+        public DestinationCacheKey(Destination destination) {
+            this.destination = destination;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            DestinationCacheKey that = (DestinationCacheKey) obj;
+            return destination != null ? destination.equals(that.destination) : that.destination == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return destination != null ? destination.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "DestinationCacheKey{destination=" + destination + "}";
+        }
+    }
+}

--- a/src/test/java/com/azure/servicebus/jms/jndi/TestUtils.java
+++ b/src/test/java/com/azure/servicebus/jms/jndi/TestUtils.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import javax.naming.NamingException;
 import javax.naming.Reference;
 
-class TestUtils {
-    static final String TEST_CONNECTION_STRING = System.getenv("SERVICE_BUS_CONNECTION_STRING");
+public class TestUtils {
+    public static final String TEST_CONNECTION_STRING = System.getenv("SERVICE_BUS_CONNECTION_STRING");
 
     static void testInvalidJNDIStorable(JNDIStorable invalidStorable, String propertyName) throws Exception {
         boolean caughtExpectedException = false;


### PR DESCRIPTION
This PR addresses a bug where Spring JMS CachingConnectionFactory was not able to cache any producer or consumer objects. This is because the equals relation was not implemented on ServiceBusJMSQueue object or ServiceBusJMSTopic object. This was causing the DestinationCacheKey to assume a unique code every time and thus the CachingConnectionFactory was not able to Cache producers.

Added the equals method for both ServiceBusJMSQueue and ServiceBusJMSTopic objects.
Added corresponding tests as well as corresponding DestinationCacheKey mock tests just like Spring CachingConnectionFactory would do.