### PR TITLE
fix(jms): support SharedAccessSignature in connection string

### DIFF
--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -82,13 +82,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.settings = settings;
         this.password = connectionStringBuilder.getSasKey();
         this.userName = connectionStringBuilder.getSasKeyName();
-        if (this.password == null && this.userName == null) {
-            String sasToken = connectionStringBuilder.getSharedAccessSignatureToken();
-            if (sasToken != null) {
-                this.password = sasToken;
-                this.userName = extractSknFromSasToken(sasToken);
-            }
-        }
+        applySasTokenCredentialsIfNeeded(connectionStringBuilder);
         this.host = connectionStringBuilder.getEndpoint().getHost();
         this.initializeWithSas();
     }
@@ -356,13 +350,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.builder = new ConnectionStringBuilder(connectionString);
         this.password = this.builder.getSasKey();
         this.userName = this.builder.getSasKeyName();
-        if (this.password == null && this.userName == null) {
-            String sasToken = this.builder.getSharedAccessSignatureToken();
-            if (sasToken != null) {
-                this.password = sasToken;
-                this.userName = extractSknFromSasToken(sasToken);
-            }
-        }
+        applySasTokenCredentialsIfNeeded(this.builder);
         this.host = this.builder.getEndpoint().getHost();
         this.initializeWithSas();
     
@@ -457,6 +445,20 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
 		this.factory.setExtension(JmsConnectionExtensions.PASSWORD_OVERRIDE.toString(), (connection, uri) -> {	
 			return this.aadAuthentication.getAadToken();
 	    });
+    }
+
+    /**
+     * If no SAS key/name credentials were found, fall back to the pre-generated SAS token
+     * from the connection string, extracting the 'skn' parameter as the username.
+     */
+    private void applySasTokenCredentialsIfNeeded(ConnectionStringBuilder connectionStringBuilder) {
+        if (this.password == null && this.userName == null) {
+            String sasToken = connectionStringBuilder.getSharedAccessSignatureToken();
+            if (sasToken != null) {
+                this.password = sasToken;
+                this.userName = extractSknFromSasToken(sasToken);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -82,6 +82,13 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.settings = settings;
         this.password = connectionStringBuilder.getSasKey();
         this.userName = connectionStringBuilder.getSasKeyName();
+        if (this.password == null && this.userName == null) {
+            String sasToken = connectionStringBuilder.getSharedAccessSignatureToken();
+            if (sasToken != null) {
+                this.password = sasToken;
+                this.userName = extractSknFromSasToken(sasToken);
+            }
+        }
         this.host = connectionStringBuilder.getEndpoint().getHost();
         this.initializeWithSas();
     }
@@ -348,7 +355,14 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.checkRequiredProperty(CONNECTION_STRING_PROPERTY, connectionString);
         this.builder = new ConnectionStringBuilder(connectionString);
         this.password = this.builder.getSasKey();
-        this.userName = this.builder.getSasKeyName(); 
+        this.userName = this.builder.getSasKeyName();
+        if (this.password == null && this.userName == null) {
+            String sasToken = this.builder.getSharedAccessSignatureToken();
+            if (sasToken != null) {
+                this.password = sasToken;
+                this.userName = extractSknFromSasToken(sasToken);
+            }
+        }
         this.host = this.builder.getEndpoint().getHost();
         this.initializeWithSas();
     
@@ -443,5 +457,33 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
 		this.factory.setExtension(JmsConnectionExtensions.PASSWORD_OVERRIDE.toString(), (connection, uri) -> {	
 			return this.aadAuthentication.getAadToken();
 	    });
+    }
+
+    /**
+     * Extract the 'skn' (Shared Access Key Name) parameter from a SAS token string.
+     * SAS token format: SharedAccessSignature sr=<resource>&sig=<signature>&se=<expiry>&skn=<keyName>
+     * @param sasToken The full SAS token string
+     * @return The value of the skn parameter, or null if not found
+     */
+    private static String extractSknFromSasToken(String sasToken) {
+        if (sasToken == null || sasToken.isEmpty()) {
+            return null;
+        }
+
+        // The token may start with "SharedAccessSignature " prefix before the key-value pairs
+        String parameterPart = sasToken;
+        int spaceIndex = sasToken.indexOf(' ');
+        if (spaceIndex >= 0) {
+            parameterPart = sasToken.substring(spaceIndex + 1);
+        }
+
+        for (String part : parameterPart.split("&")) {
+            String[] keyValue = part.split("=", 2);
+            if (keyValue.length == 2 && "skn".equalsIgnoreCase(keyValue[0].trim())) {
+                return keyValue[1].trim();
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -84,7 +84,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.settings = settings;
         this.password = connectionStringBuilder.getSasKey();
         this.userName = connectionStringBuilder.getSasKeyName();
-        applySasTokenCredentialsIfNeeded(connectionStringBuilder);
+        this.applySasTokenCredentialsIfNeeded(connectionStringBuilder);
         this.host = connectionStringBuilder.getEndpoint().getHost();
         this.initializeWithSas();
     }
@@ -352,7 +352,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         this.builder = new ConnectionStringBuilder(connectionString);
         this.password = this.builder.getSasKey();
         this.userName = this.builder.getSasKeyName();
-        applySasTokenCredentialsIfNeeded(this.builder);
+        this.applySasTokenCredentialsIfNeeded(this.builder);
         this.host = this.builder.getEndpoint().getHost();
         this.initializeWithSas();
     
@@ -456,14 +456,14 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
     private void applySasTokenCredentialsIfNeeded(ConnectionStringBuilder connectionStringBuilder) {
         if (this.password == null && this.userName == null) {
             String sasToken = connectionStringBuilder.getSharedAccessSignatureToken();
-            if (sasToken != null) {
-                this.password = sasToken;
-                String skn = extractSknFromSasToken(sasToken);
+            if (sasToken != null && !sasToken.isEmpty()) {
+                String skn = this.extractSknFromSasToken(sasToken);
                 if (skn == null || skn.isEmpty()) {
                     throw new IllegalArgumentException(
                             "The SharedAccessSignature token is missing the required 'skn' (shared access key name) parameter.");
                 }
                 this.userName = skn;
+                this.password = sasToken;
             }
         }
     }
@@ -474,7 +474,7 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
      * @param sasToken The full SAS token string
      * @return The value of the skn parameter, or null if not found
      */
-    private static String extractSknFromSasToken(String sasToken) {
+    private String extractSknFromSasToken(String sasToken) {
         if (sasToken == null || sasToken.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
+++ b/src/main/java/com/azure/servicebus/jms/ServiceBusJmsConnectionFactory.java
@@ -4,8 +4,10 @@
 package com.azure.servicebus.jms;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -456,7 +458,12 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
             String sasToken = connectionStringBuilder.getSharedAccessSignatureToken();
             if (sasToken != null) {
                 this.password = sasToken;
-                this.userName = extractSknFromSasToken(sasToken);
+                String skn = extractSknFromSasToken(sasToken);
+                if (skn == null || skn.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "The SharedAccessSignature token is missing the required 'skn' (shared access key name) parameter.");
+                }
+                this.userName = skn;
             }
         }
     }
@@ -482,7 +489,11 @@ public class ServiceBusJmsConnectionFactory extends JNDIStorable implements Conn
         for (String part : parameterPart.split("&")) {
             String[] keyValue = part.split("=", 2);
             if (keyValue.length == 2 && "skn".equalsIgnoreCase(keyValue[0].trim())) {
-                return keyValue[1].trim();
+                try {
+                    return URLDecoder.decode(keyValue[1].trim(), "UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    return keyValue[1].trim();
+                }
             }
         }
 

--- a/src/test/java/com/azure/servicebus/jms/connection/string/SasTokenConnectionStringTest.java
+++ b/src/test/java/com/azure/servicebus/jms/connection/string/SasTokenConnectionStringTest.java
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package com.azure.servicebus.jms.connection.string;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import javax.naming.Reference;
+
+import com.azure.servicebus.jms.ConnectionStringBuilder;
+import com.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+import com.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings;
+import com.azure.servicebus.jms.jndi.JNDIReferenceFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for SAS token-based connection string support in ServiceBusJmsConnectionFactory.
+ * Covers the fix for azure-servicebus-jms#58: the factory previously threw
+ * IllegalArgumentException when initialized with a connection string containing
+ * SharedAccessSignature instead of SharedAccessKeyName/SharedAccessKey.
+ */
+public class SasTokenConnectionStringTest {
+
+    private static final String SAS_TOKEN =
+            "SharedAccessSignature sr=sb%3A%2F%2Ftest-ns.servicebus.windows.net&sig=dummySig&se=1735689600&skn=TestPolicy";
+    private static final String SAS_TOKEN_CONNECTION_STRING =
+            "Endpoint=sb://test-ns.servicebus.windows.net/;SharedAccessSignature=" + SAS_TOKEN;
+    private static final String SAS_KEY_CONNECTION_STRING =
+            "Endpoint=sb://test-ns.servicebus.windows.net/;SharedAccessKeyName=TestPolicy;SharedAccessKey=dummyKey123";
+
+    /**
+     * Verifies that a connection string with SharedAccessSignature (pre-generated SAS token)
+     * can be used to create a factory via the String constructor without throwing.
+     * This is the primary scenario reported in issue #58.
+     */
+    @Test
+    public void createFactoryWithSasTokenConnectionString() {
+        ServiceBusJmsConnectionFactory factory = assertDoesNotThrow(() ->
+                new ServiceBusJmsConnectionFactory(SAS_TOKEN_CONNECTION_STRING, null));
+        assertNotNull(factory);
+        assertNotNull(factory.getRemoteConnectionUri());
+    }
+
+    /**
+     * Verifies that a connection string with SharedAccessSignature works via
+     * the ConnectionStringBuilder constructor path.
+     */
+    @Test
+    public void createFactoryWithSasTokenViaConnectionStringBuilder() {
+        ConnectionStringBuilder builder = new ConnectionStringBuilder(SAS_TOKEN_CONNECTION_STRING);
+        ServiceBusJmsConnectionFactory factory = assertDoesNotThrow(() ->
+                new ServiceBusJmsConnectionFactory(builder, null));
+        assertNotNull(factory);
+        assertNotNull(factory.getRemoteConnectionUri());
+    }
+
+    /**
+     * Verifies that the factory extracts the correct host from a SAS token connection string.
+     * The remote URI should contain the host from the Endpoint property.
+     */
+    @Test
+    public void sasTokenConnectionStringExtractsCorrectHost() {
+        ServiceBusJmsConnectionFactory factory =
+                new ServiceBusJmsConnectionFactory(SAS_TOKEN_CONNECTION_STRING, null);
+        String remoteUri = factory.getRemoteConnectionUri();
+        assertNotNull(remoteUri);
+        // The URI should contain the host from the connection string
+        assertEquals(true, remoteUri.contains("test-ns.servicebus.windows.net"),
+                "Remote URI should contain the namespace host");
+    }
+
+    /**
+     * Verifies that using custom settings with a SAS token connection string still works.
+     */
+    @Test
+    public void sasTokenConnectionStringWithSettings() {
+        ServiceBusJmsConnectionFactorySettings settings = new ServiceBusJmsConnectionFactorySettings();
+        settings.setShouldReconnect(false);
+        ServiceBusJmsConnectionFactory factory = assertDoesNotThrow(() ->
+                new ServiceBusJmsConnectionFactory(SAS_TOKEN_CONNECTION_STRING, settings));
+        assertNotNull(factory);
+    }
+
+    /**
+     * Regression test: Verifies that the traditional SharedAccessKeyName/SharedAccessKey
+     * connection string still works after the SAS token fix.
+     */
+    @Test
+    public void sasKeyConnectionStringStillWorks() {
+        ServiceBusJmsConnectionFactory factory = assertDoesNotThrow(() ->
+                new ServiceBusJmsConnectionFactory(SAS_KEY_CONNECTION_STRING, null));
+        assertNotNull(factory);
+        assertNotNull(factory.getRemoteConnectionUri());
+    }
+
+    /**
+     * Verifies that a connection string with SharedAccessSignatureToken (alternate key name)
+     * also works. The ConnectionStringBuilder accepts both 'SharedAccessSignature' and
+     * 'SharedAccessSignatureToken' as valid key names.
+     */
+    @Test
+    public void createFactoryWithSharedAccessSignatureTokenKey() {
+        String connectionString =
+                "Endpoint=sb://test-ns.servicebus.windows.net/;SharedAccessSignatureToken=" + SAS_TOKEN;
+        ServiceBusJmsConnectionFactory factory = assertDoesNotThrow(() ->
+                new ServiceBusJmsConnectionFactory(connectionString, null));
+        assertNotNull(factory);
+    }
+
+    /**
+     * Verifies that a connection string with neither SAS key/name nor SAS token
+     * still throws IllegalArgumentException (no auth credentials at all).
+     */
+    @Test
+    public void connectionStringWithNoAuthThrows() {
+        String noAuthConnectionString = "Endpoint=sb://test-ns.servicebus.windows.net/";
+        assertThrows(IllegalArgumentException.class, () ->
+                new ServiceBusJmsConnectionFactory(noAuthConnectionString, null));
+    }
+
+    /**
+     * Verifies the JNDI round-trip path: a factory created with a SAS token connection
+     * string can be stored as a JNDI Reference and recreated via JNDIReferenceFactory.
+     * The recreated factory should initialize without throwing (EP-3: setProperties path).
+     */
+    @Test
+    public void jndiRoundTripWithSasTokenConnectionString() throws Exception {
+        ServiceBusJmsConnectionFactory original =
+                new ServiceBusJmsConnectionFactory(SAS_TOKEN_CONNECTION_STRING, null);
+        Reference reference = original.getReference();
+        assertNotNull(reference);
+
+        JNDIReferenceFactory referenceFactory = new JNDIReferenceFactory();
+        ServiceBusJmsConnectionFactory restored = (ServiceBusJmsConnectionFactory)
+                referenceFactory.getObjectInstance(reference, null, null, null);
+        assertNotNull(restored);
+        assertNotNull(restored.getRemoteConnectionUri());
+    }
+}

--- a/src/test/java/com/azure/servicebus/jms/connection/string/SasTokenConnectionStringTest.java
+++ b/src/test/java/com/azure/servicebus/jms/connection/string/SasTokenConnectionStringTest.java
@@ -4,11 +4,9 @@
 package com.azure.servicebus.jms.connection.string;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.naming.Reference;
 
@@ -70,7 +68,7 @@ public class SasTokenConnectionStringTest {
         String remoteUri = factory.getRemoteConnectionUri();
         assertNotNull(remoteUri);
         // The URI should contain the host from the connection string
-        assertEquals(true, remoteUri.contains("test-ns.servicebus.windows.net"),
+        assertTrue(remoteUri.contains("test-ns.servicebus.windows.net"),
                 "Remote URI should contain the namespace host");
     }
 

--- a/src/test/java/com/azure/servicebus/jms/connection/string/SasTokenConnectionStringTest.java
+++ b/src/test/java/com/azure/servicebus/jms/connection/string/SasTokenConnectionStringTest.java
@@ -97,9 +97,10 @@ public class SasTokenConnectionStringTest {
     }
 
     /**
-     * Verifies that a connection string with SharedAccessSignatureToken (alternate key name)
-     * also works. The ConnectionStringBuilder accepts both 'SharedAccessSignature' and
-     * 'SharedAccessSignatureToken' as valid key names.
+     * Verifies that a connection string with SharedAccessSignatureToken (the primary
+     * key name in ConnectionStringBuilder) also works. The ConnectionStringBuilder
+     * accepts both 'SharedAccessSignatureToken' (primary) and 'SharedAccessSignature'
+     * (alternate) as valid key names for the SAS token property.
      */
     @Test
     public void createFactoryWithSharedAccessSignatureTokenKey() {
@@ -119,6 +120,20 @@ public class SasTokenConnectionStringTest {
         String noAuthConnectionString = "Endpoint=sb://test-ns.servicebus.windows.net/";
         assertThrows(IllegalArgumentException.class, () ->
                 new ServiceBusJmsConnectionFactory(noAuthConnectionString, null));
+    }
+
+    /**
+     * Verifies that a SAS token missing the required 'skn' parameter throws
+     * a targeted IllegalArgumentException instead of a generic null error.
+     */
+    @Test
+    public void sasTokenWithoutSknThrowsTargetedException() {
+        String tokenWithoutSkn = "SharedAccessSignature sr=sb%3A%2F%2Ftest-ns.servicebus.windows.net&sig=dummySig&se=1735689600";
+        String connectionString = "Endpoint=sb://test-ns.servicebus.windows.net/;SharedAccessSignature=" + tokenWithoutSkn;
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                new ServiceBusJmsConnectionFactory(connectionString, null));
+        assertTrue(ex.getMessage().contains("skn"),
+                "Exception should mention the missing 'skn' parameter");
     }
 
     /**


### PR DESCRIPTION
## Problem

`ServiceBusJmsConnectionFactory` throws `IllegalArgumentException("Authentication settings and host cannot be null...")` when initialized with a connection string that uses a pre-generated `SharedAccessSignature` token instead of `SharedAccessKeyName`/`SharedAccessKey` credentials.

The underlying `ConnectionStringBuilder` correctly parses the `SharedAccessSignature` property, but the factory only reads `getSasKey()` and `getSasKeyName()` — both of which return null for SAS-token-based connection strings.

**Impact:** Customers in federated auth scenarios who only have pre-generated SAS tokens (without access to the signing key) cannot use the JMS library at all. This affects both direct users and Spring Cloud Azure JMS users (`spring-cloud-azure-starter-servicebus-jms`).

## Fix

After `getSasKey()`/`getSasKeyName()` return null, fall back to `getSharedAccessSignatureToken()`. Extract the `skn` parameter from the SAS token for the AMQP username (the SAS policy name) and use the full token string as the password.

Applied to both:
- **EP-1:** `ConnectionStringBuilder`-based constructor (line 85)
- **EP-3:** `setProperties()` JNDI path (line 358)

Added a private `extractSknFromSasToken()` helper that parses the `skn=<value>` parameter from the SAS token string.

## Design Decision

Single enforcement point at the credential extraction step (EP-1 and EP-3), keeping `initialize()` and `initializeWithSas()` unchanged. The fallback only activates when both `getSasKey()` and `getSasKeyName()` are null, so existing SAS key/name and AAD paths are completely unaffected.

This matches how the .NET and Python SDKs handle SAS token connection strings.

**Limitation:** Pre-generated SAS tokens are static and cannot be refreshed mid-connection. This is consistent with how every other SDK handles pre-built SAS tokens (no SDK refreshes them). A future enhancement could add a `PASSWORD_OVERRIDE` callback for token refresh on reconnect.

## Testing

- `SasTokenConnectionStringTest` — 8 new unit tests:
  - Factory creation with SAS token connection string (String and ConnectionStringBuilder paths)
  - Host extraction, custom settings
  - `SharedAccessSignatureToken` alternate key name
  - Regression: SAS key/name connection string still works
  - No-auth connection string still throws
  - JNDI round-trip with SAS token connection string
- All 24 unit tests pass (8 new + 16 existing). Integration tests (requiring live connection) are unaffected.

Fixes #58
Related: Azure/azure-sdk-for-java#47381
